### PR TITLE
Add async support to TX commands

### DIFF
--- a/auction/auction.go
+++ b/auction/auction.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
@@ -566,6 +567,16 @@ func RecoverUnclaimedRPL(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.
         return common.Hash{}, fmt.Errorf("Could not recover unclaimed RPL from lot %d: %w", lotIndex, err)
     }
     return hash, nil
+}
+
+
+// Wait for a transaction to get mined
+func WaitForTransaction(rp *rocketpool.RocketPool, hash common.Hash) (*types.Receipt, error) {
+    rocketAuctionManager, err := getRocketAuctionManager(rp)
+    if err != nil {
+        return nil, err
+    }
+    return rocketAuctionManager.WaitForTransaction(hash)
 }
 
 

--- a/auction/auction.go
+++ b/auction/auction.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
@@ -567,16 +566,6 @@ func RecoverUnclaimedRPL(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.
         return common.Hash{}, fmt.Errorf("Could not recover unclaimed RPL from lot %d: %w", lotIndex, err)
     }
     return hash, nil
-}
-
-
-// Wait for a transaction to get mined
-func WaitForTransaction(rp *rocketpool.RocketPool, hash common.Hash) (*types.Receipt, error) {
-    rocketAuctionManager, err := getRocketAuctionManager(rp)
-    if err != nil {
-        return nil, err
-    }
-    return rocketAuctionManager.WaitForTransaction(hash)
 }
 
 

--- a/auction/auction.go
+++ b/auction/auction.go
@@ -1,18 +1,16 @@
 package auction
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
-    "golang.org/x/sync/errgroup"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/sync/errgroup"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Settings
 const LotDetailsBatchSize = 10
@@ -512,62 +510,62 @@ func GetLotAddressBidAmount(rp *rocketpool.RocketPool, lotIndex uint64, bidder c
 
 
 // Create a new lot
-func CreateLot(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func CreateLot(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     rocketAuctionManager, err := getRocketAuctionManager(rp)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
     lotCount, err := GetLotCount(rp, nil)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
-    txReceipt, err := rocketAuctionManager.Transact(opts, "createLot")
+    hash, err := rocketAuctionManager.Transact(opts, "createLot")
     if err != nil {
-        return 0, nil, fmt.Errorf("Could not create lot: %w", err)
+        return 0, common.Hash{}, fmt.Errorf("Could not create lot: %w", err)
     }
-    return lotCount, txReceipt, nil
+    return lotCount, hash, nil
 }
 
 
 // Place a bid on a lot
-func PlaceBid(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func PlaceBid(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.TransactOpts) (common.Hash, error) {
     rocketAuctionManager, err := getRocketAuctionManager(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketAuctionManager.Transact(opts, "placeBid", big.NewInt(int64(lotIndex)))
+    hash, err := rocketAuctionManager.Transact(opts, "placeBid", big.NewInt(int64(lotIndex)))
     if err != nil {
-        return nil, fmt.Errorf("Could not place bid on lot %d: %w", lotIndex, err)
+        return common.Hash{}, fmt.Errorf("Could not place bid on lot %d: %w", lotIndex, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Claim RPL from a lot that was bid on
-func ClaimBid(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func ClaimBid(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.TransactOpts) (common.Hash, error) {
     rocketAuctionManager, err := getRocketAuctionManager(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketAuctionManager.Transact(opts, "claimBid", big.NewInt(int64(lotIndex)))
+    hash, err := rocketAuctionManager.Transact(opts, "claimBid", big.NewInt(int64(lotIndex)))
     if err != nil {
-        return nil, fmt.Errorf("Could not claim bid from lot %d: %w", lotIndex, err)
+        return common.Hash{}, fmt.Errorf("Could not claim bid from lot %d: %w", lotIndex, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Recover unclaimed RPL from a lot
-func RecoverUnclaimedRPL(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func RecoverUnclaimedRPL(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.TransactOpts) (common.Hash, error) {
     rocketAuctionManager, err := getRocketAuctionManager(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketAuctionManager.Transact(opts, "recoverUnclaimedRPL", big.NewInt(int64(lotIndex)))
+    hash, err := rocketAuctionManager.Transact(opts, "recoverUnclaimedRPL", big.NewInt(int64(lotIndex)))
     if err != nil {
-        return nil, fmt.Errorf("Could not recover unclaimed RPL from lot %d: %w", lotIndex, err)
+        return common.Hash{}, fmt.Errorf("Could not recover unclaimed RPL from lot %d: %w", lotIndex, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/dao/protocol/dao.go
+++ b/dao/protocol/dao.go
@@ -1,72 +1,70 @@
 package protocol
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
 
-
 // Bootstrap a bool setting
-func BootstrapBool(rp *rocketpool.RocketPool, contractName, settingPath string, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapBool(rp *rocketpool.RocketPool, contractName, settingPath string, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAOProtocol, err := getRocketDAOProtocol(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingBool", contractName, settingPath, value)
+    hash, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingBool", contractName, settingPath, value)
     if err != nil {
-        return nil, fmt.Errorf("Could not bootstrap protocol setting %s.%s: %w", contractName, settingPath, err)
+        return common.Hash{}, fmt.Errorf("Could not bootstrap protocol setting %s.%s: %w", contractName, settingPath, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Bootstrap a uint256 setting
-func BootstrapUint(rp *rocketpool.RocketPool, contractName, settingPath string, value *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapUint(rp *rocketpool.RocketPool, contractName, settingPath string, value *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAOProtocol, err := getRocketDAOProtocol(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingUint", contractName, settingPath, value)
+    hash, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingUint", contractName, settingPath, value)
     if err != nil {
-        return nil, fmt.Errorf("Could not bootstrap protocol setting %s.%s: %w", contractName, settingPath, err)
+        return common.Hash{}, fmt.Errorf("Could not bootstrap protocol setting %s.%s: %w", contractName, settingPath, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Bootstrap an address setting
-func BootstrapAddress(rp *rocketpool.RocketPool, contractName, settingPath string, value common.Address, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapAddress(rp *rocketpool.RocketPool, contractName, settingPath string, value common.Address, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAOProtocol, err := getRocketDAOProtocol(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingAddress", contractName, settingPath, value)
+    hash, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingAddress", contractName, settingPath, value)
     if err != nil {
-        return nil, fmt.Errorf("Could not bootstrap protocol setting %s.%s: %w", contractName, settingPath, err)
+        return common.Hash{}, fmt.Errorf("Could not bootstrap protocol setting %s.%s: %w", contractName, settingPath, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Bootstrap a rewards claimer
-func BootstrapClaimer(rp *rocketpool.RocketPool, contractName string, amount float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapClaimer(rp *rocketpool.RocketPool, contractName string, amount float64, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAOProtocol, err := getRocketDAOProtocol(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingClaimer", contractName, eth.EthToWei(amount))
+    hash, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingClaimer", contractName, eth.EthToWei(amount))
     if err != nil {
-        return nil, fmt.Errorf("Could not bootstrap protocol rewards claimer %s: %w", contractName, err)
+        return common.Hash{}, fmt.Errorf("Could not bootstrap protocol rewards claimer %s: %w", contractName, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/dao/trustednode/actions.go
+++ b/dao/trustednode/actions.go
@@ -1,87 +1,85 @@
 package trustednode
 
 import (
-    "fmt"
-    "sync"
+	"fmt"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Join the trusted node DAO
 // Requires an executed invite proposal
-func Join(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func Join(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrustedActions, err := getRocketDAONodeTrustedActions(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrustedActions.Transact(opts, "actionJoin")
+    hash, err := rocketDAONodeTrustedActions.Transact(opts, "actionJoin")
     if err != nil {
-        return nil, fmt.Errorf("Could not join the trusted node DAO: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not join the trusted node DAO: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Leave the trusted node DAO
 // Requires an executed leave proposal
-func Leave(rp *rocketpool.RocketPool, rplBondRefundAddress common.Address, opts *bind.TransactOpts) (*types.Receipt, error) {
+func Leave(rp *rocketpool.RocketPool, rplBondRefundAddress common.Address, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrustedActions, err := getRocketDAONodeTrustedActions(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrustedActions.Transact(opts, "actionLeave", rplBondRefundAddress)
+    hash, err := rocketDAONodeTrustedActions.Transact(opts, "actionLeave", rplBondRefundAddress)
     if err != nil {
-        return nil, fmt.Errorf("Could not leave the trusted node DAO: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not leave the trusted node DAO: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Replace node's position in the trusted node DAO with another node
 // Requires an executed replace proposal
-func Replace(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func Replace(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrustedActions, err := getRocketDAONodeTrustedActions(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrustedActions.Transact(opts, "actionReplace")
+    hash, err := rocketDAONodeTrustedActions.Transact(opts, "actionReplace")
     if err != nil {
-        return nil, fmt.Errorf("Could not replace node's position in the trusted node DAO: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not replace node's position in the trusted node DAO: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Make a challenge against a node
-func MakeChallenge(rp *rocketpool.RocketPool, memberAddress common.Address, opts *bind.TransactOpts) (*types.Receipt, error) {
+func MakeChallenge(rp *rocketpool.RocketPool, memberAddress common.Address, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrustedActions, err := getRocketDAONodeTrustedActions(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrustedActions.Transact(opts, "actionChallengeMake", memberAddress)
+    hash, err := rocketDAONodeTrustedActions.Transact(opts, "actionChallengeMake", memberAddress)
     if err != nil {
-        return nil, fmt.Errorf("Could not challenge trusted node DAO member %s: %w", memberAddress.Hex(), err)
+        return common.Hash{}, fmt.Errorf("Could not challenge trusted node DAO member %s: %w", memberAddress.Hex(), err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Decide a challenge against a node
-func DecideChallenge(rp *rocketpool.RocketPool, memberAddress common.Address, opts *bind.TransactOpts) (*types.Receipt, error) {
+func DecideChallenge(rp *rocketpool.RocketPool, memberAddress common.Address, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrustedActions, err := getRocketDAONodeTrustedActions(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrustedActions.Transact(opts, "actionChallengeDecide", memberAddress)
+    hash, err := rocketDAONodeTrustedActions.Transact(opts, "actionChallengeDecide", memberAddress)
     if err != nil {
-        return nil, fmt.Errorf("Could not decide the challenge against trusted node DAO member %s: %w", memberAddress.Hex(), err)
+        return common.Hash{}, fmt.Errorf("Could not decide the challenge against trusted node DAO member %s: %w", memberAddress.Hex(), err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/dao/trustednode/dao.go
+++ b/dao/trustednode/dao.go
@@ -1,19 +1,17 @@
 package trustednode
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
-    "golang.org/x/sync/errgroup"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/sync/errgroup"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/strings"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/strings"
 )
-
 
 // Settings
 const (
@@ -360,62 +358,62 @@ func GetMemberIsChallenged(rp *rocketpool.RocketPool, memberAddress common.Addre
 
 
 // Bootstrap a bool setting
-func BootstrapBool(rp *rocketpool.RocketPool, contractName, settingPath string, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapBool(rp *rocketpool.RocketPool, contractName, settingPath string, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrusted, err := getRocketDAONodeTrusted(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrusted.Transact(opts, "bootstrapSettingBool", contractName, settingPath, value)
+    hash, err := rocketDAONodeTrusted.Transact(opts, "bootstrapSettingBool", contractName, settingPath, value)
     if err != nil {
-        return nil, fmt.Errorf("Could not bootstrap trusted node setting %s.%s: %w", contractName, settingPath, err)
+        return common.Hash{}, fmt.Errorf("Could not bootstrap trusted node setting %s.%s: %w", contractName, settingPath, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Bootstrap a uint256 setting
-func BootstrapUint(rp *rocketpool.RocketPool, contractName, settingPath string, value *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapUint(rp *rocketpool.RocketPool, contractName, settingPath string, value *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrusted, err := getRocketDAONodeTrusted(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrusted.Transact(opts, "bootstrapSettingUint", contractName, settingPath, value)
+    hash, err := rocketDAONodeTrusted.Transact(opts, "bootstrapSettingUint", contractName, settingPath, value)
     if err != nil {
-        return nil, fmt.Errorf("Could not bootstrap trusted node setting %s.%s: %w", contractName, settingPath, err)
+        return common.Hash{}, fmt.Errorf("Could not bootstrap trusted node setting %s.%s: %w", contractName, settingPath, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Bootstrap a DAO member
-func BootstrapMember(rp *rocketpool.RocketPool, id, email string, nodeAddress common.Address, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMember(rp *rocketpool.RocketPool, id, email string, nodeAddress common.Address, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrusted, err := getRocketDAONodeTrusted(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrusted.Transact(opts, "bootstrapMember", id, email, nodeAddress)
+    hash, err := rocketDAONodeTrusted.Transact(opts, "bootstrapMember", id, email, nodeAddress)
     if err != nil {
-        return nil, fmt.Errorf("Could not bootstrap trusted node member %s: %w", id, err)
+        return common.Hash{}, fmt.Errorf("Could not bootstrap trusted node member %s: %w", id, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Bootstrap a contract upgrade
-func BootstrapUpgrade(rp *rocketpool.RocketPool, upgradeType, contractName, contractAbi string, contractAddress common.Address, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapUpgrade(rp *rocketpool.RocketPool, upgradeType, contractName, contractAbi string, contractAddress common.Address, opts *bind.TransactOpts) (common.Hash, error) {
     compressedAbi, err := rocketpool.EncodeAbiStr(contractAbi)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     rocketDAONodeTrusted, err := getRocketDAONodeTrusted(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrusted.Transact(opts, "bootstrapUpgrade", upgradeType, contractName, compressedAbi, contractAddress)
+    hash, err := rocketDAONodeTrusted.Transact(opts, "bootstrapUpgrade", upgradeType, contractName, compressedAbi, contractAddress)
     if err != nil {
-        return nil, fmt.Errorf("Could not bootstrap contract '%s' upgrade (%s): %w", contractName, upgradeType, err)
+        return common.Hash{}, fmt.Errorf("Could not bootstrap contract '%s' upgrade (%s): %w", contractName, upgradeType, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/dao/trustednode/proposals.go
+++ b/dao/trustednode/proposals.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/rocket-pool/rocketpool-go/dao"
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
@@ -173,16 +172,6 @@ func ExecuteProposal(rp *rocketpool.RocketPool, proposalId uint64, opts *bind.Tr
         return common.Hash{}, fmt.Errorf("Could not execute trusted node DAO proposal %d: %w", proposalId, err)
     }
     return hash, nil
-}
-
-
-// Wait for a transaction to get mined
-func WaitForTransaction(rp *rocketpool.RocketPool, hash common.Hash) (*types.Receipt, error) {
-    rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
-    if err != nil {
-        return nil, err
-    }
-    return rocketDAONodeTrustedProposals.WaitForTransaction(hash)
 }
 
 

--- a/dao/trustednode/proposals.go
+++ b/dao/trustednode/proposals.go
@@ -1,116 +1,114 @@
 package trustednode
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/dao"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/dao"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
 
-
 // Submit a proposal to invite a new member to the trusted node DAO
-func ProposeInviteMember(rp *rocketpool.RocketPool, message string, newMemberAddress common.Address, newMemberId, newMemberEmail string, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeInviteMember(rp *rocketpool.RocketPool, message string, newMemberAddress common.Address, newMemberId, newMemberEmail string, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
     payload, err := rocketDAONodeTrustedProposals.ABI.Pack("proposalInvite", newMemberId, newMemberEmail, newMemberAddress)
     if err != nil {
-        return 0, nil, fmt.Errorf("Could not encode invite member proposal payload: %w", err)
+        return 0, common.Hash{}, fmt.Errorf("Could not encode invite member proposal payload: %w", err)
     }
     return SubmitProposal(rp, message, payload, opts)
 }
 
 
 // Submit a proposal for a member to leave the trusted node DAO
-func ProposeMemberLeave(rp *rocketpool.RocketPool, message string, memberAddress common.Address, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeMemberLeave(rp *rocketpool.RocketPool, message string, memberAddress common.Address, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
     payload, err := rocketDAONodeTrustedProposals.ABI.Pack("proposalLeave", memberAddress)
     if err != nil {
-        return 0, nil, fmt.Errorf("Could not encode member leave proposal payload: %w", err)
+        return 0, common.Hash{}, fmt.Errorf("Could not encode member leave proposal payload: %w", err)
     }
     return SubmitProposal(rp, message, payload, opts)
 }
 
 
 // Submit a proposal to replace a member in the trusted node DAO
-func ProposeReplaceMember(rp *rocketpool.RocketPool, message string, memberAddress, newMemberAddress common.Address, newMemberId, newMemberEmail string, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeReplaceMember(rp *rocketpool.RocketPool, message string, memberAddress, newMemberAddress common.Address, newMemberId, newMemberEmail string, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
     payload, err := rocketDAONodeTrustedProposals.ABI.Pack("proposalReplace", memberAddress, newMemberId, newMemberEmail, newMemberAddress)
     if err != nil {
-        return 0, nil, fmt.Errorf("Could not encode replace member proposal payload: %w", err)
+        return 0, common.Hash{}, fmt.Errorf("Could not encode replace member proposal payload: %w", err)
     }
     return SubmitProposal(rp, message, payload, opts)
 }
 
 
 // Submit a proposal to kick a member from the trusted node DAO
-func ProposeKickMember(rp *rocketpool.RocketPool, message string, memberAddress common.Address, rplFineAmount *big.Int, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeKickMember(rp *rocketpool.RocketPool, message string, memberAddress common.Address, rplFineAmount *big.Int, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
     payload, err := rocketDAONodeTrustedProposals.ABI.Pack("proposalKick", memberAddress, rplFineAmount)
     if err != nil {
-        return 0, nil, fmt.Errorf("Could not encode kick member proposal payload: %w", err)
+        return 0, common.Hash{}, fmt.Errorf("Could not encode kick member proposal payload: %w", err)
     }
     return SubmitProposal(rp, message, payload, opts)
 }
 
 
 // Submit a proposal to update a bool trusted node DAO setting
-func ProposeSetBool(rp *rocketpool.RocketPool, message, contractName, settingPath string, value bool, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeSetBool(rp *rocketpool.RocketPool, message, contractName, settingPath string, value bool, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
     payload, err := rocketDAONodeTrustedProposals.ABI.Pack("proposalSettingBool", contractName, settingPath, value)
     if err != nil {
-        return 0, nil, fmt.Errorf("Could not encode set bool setting proposal payload: %w", err)
+        return 0, common.Hash{}, fmt.Errorf("Could not encode set bool setting proposal payload: %w", err)
     }
     return SubmitProposal(rp, message, payload, opts)
 }
 
 
 // Submit a proposal to update a uint trusted node DAO setting
-func ProposeSetUint(rp *rocketpool.RocketPool, message, contractName, settingPath string, value *big.Int, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeSetUint(rp *rocketpool.RocketPool, message, contractName, settingPath string, value *big.Int, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
     payload, err := rocketDAONodeTrustedProposals.ABI.Pack("proposalSettingUint", contractName, settingPath, value)
     if err != nil {
-        return 0, nil, fmt.Errorf("Could not encode set uint setting proposal payload: %w", err)
+        return 0, common.Hash{}, fmt.Errorf("Could not encode set uint setting proposal payload: %w", err)
     }
     return SubmitProposal(rp, message, payload, opts)
 }
 
 
 // Submit a proposal to upgrade a contract
-func ProposeUpgradeContract(rp *rocketpool.RocketPool, message, upgradeType, contractName, contractAbi string, contractAddress common.Address, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeUpgradeContract(rp *rocketpool.RocketPool, message, upgradeType, contractName, contractAbi string, contractAddress common.Address, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     compressedAbi, err := rocketpool.EncodeAbiStr(contractAbi)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
     payload, err := rocketDAONodeTrustedProposals.ABI.Pack("proposalUpgrade", upgradeType, contractName, compressedAbi, contractAddress)
     if err != nil {
-        return 0, nil, fmt.Errorf("Could not encode upgrade contract proposal payload: %w", err)
+        return 0, common.Hash{}, fmt.Errorf("Could not encode upgrade contract proposal payload: %w", err)
     }
     return SubmitProposal(rp, message, payload, opts)
 }
@@ -118,62 +116,62 @@ func ProposeUpgradeContract(rp *rocketpool.RocketPool, message, upgradeType, con
 
 // Submit a trusted node DAO proposal
 // Returns the ID of the new proposal
-func SubmitProposal(rp *rocketpool.RocketPool, message string, payload []byte, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func SubmitProposal(rp *rocketpool.RocketPool, message string, payload []byte, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
     proposalCount, err := dao.GetProposalCount(rp, nil)
     if err != nil {
-        return 0, nil, err
+        return 0, common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrustedProposals.Transact(opts, "propose", message, payload)
+    hash, err := rocketDAONodeTrustedProposals.Transact(opts, "propose", message, payload)
     if err != nil {
-        return 0, nil, fmt.Errorf("Could not submit trusted node DAO proposal: %w", err)
+        return 0, common.Hash{}, fmt.Errorf("Could not submit trusted node DAO proposal: %w", err)
     }
-    return proposalCount + 1, txReceipt, nil
+    return proposalCount + 1, hash, nil
 }
 
 
 // Cancel a submitted proposal
-func CancelProposal(rp *rocketpool.RocketPool, proposalId uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func CancelProposal(rp *rocketpool.RocketPool, proposalId uint64, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrustedProposals.Transact(opts, "cancel", big.NewInt(int64(proposalId)))
+    hash, err := rocketDAONodeTrustedProposals.Transact(opts, "cancel", big.NewInt(int64(proposalId)))
     if err != nil {
-        return nil, fmt.Errorf("Could not cancel trusted node DAO proposal %d: %w", proposalId, err)
+        return common.Hash{}, fmt.Errorf("Could not cancel trusted node DAO proposal %d: %w", proposalId, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Vote on a submitted proposal
-func VoteOnProposal(rp *rocketpool.RocketPool, proposalId uint64, support bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func VoteOnProposal(rp *rocketpool.RocketPool, proposalId uint64, support bool, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrustedProposals.Transact(opts, "vote", big.NewInt(int64(proposalId)), support)
+    hash, err := rocketDAONodeTrustedProposals.Transact(opts, "vote", big.NewInt(int64(proposalId)), support)
     if err != nil {
-        return nil, fmt.Errorf("Could not vote on trusted node DAO proposal %d: %w", proposalId, err)
+        return common.Hash{}, fmt.Errorf("Could not vote on trusted node DAO proposal %d: %w", proposalId, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Execute a submitted proposal
-func ExecuteProposal(rp *rocketpool.RocketPool, proposalId uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func ExecuteProposal(rp *rocketpool.RocketPool, proposalId uint64, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDAONodeTrustedProposals.Transact(opts, "execute", big.NewInt(int64(proposalId)))
+    hash, err := rocketDAONodeTrustedProposals.Transact(opts, "execute", big.NewInt(int64(proposalId)))
     if err != nil {
-        return nil, fmt.Errorf("Could not execute trusted node DAO proposal %d: %w", proposalId, err)
+        return common.Hash{}, fmt.Errorf("Could not execute trusted node DAO proposal %d: %w", proposalId, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/dao/trustednode/proposals.go
+++ b/dao/trustednode/proposals.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/rocket-pool/rocketpool-go/dao"
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
@@ -172,6 +173,16 @@ func ExecuteProposal(rp *rocketpool.RocketPool, proposalId uint64, opts *bind.Tr
         return common.Hash{}, fmt.Errorf("Could not execute trusted node DAO proposal %d: %w", proposalId, err)
     }
     return hash, nil
+}
+
+
+// Wait for a transaction to get mined
+func WaitForTransaction(rp *rocketpool.RocketPool, hash common.Hash) (*types.Receipt, error) {
+    rocketDAONodeTrustedProposals, err := getRocketDAONodeTrustedProposals(rp)
+    if err != nil {
+        return nil, err
+    }
+    return rocketDAONodeTrustedProposals.WaitForTransaction(hash)
 }
 
 

--- a/deposit/deposit.go
+++ b/deposit/deposit.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
@@ -65,16 +64,6 @@ func AssignDeposits(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.
         return common.Hash{}, fmt.Errorf("Could not assign deposits: %w", err)
     }
     return hash, nil
-}
-
-
-// Wait for a transaction to get mined
-func WaitForTransaction(rp *rocketpool.RocketPool, hash common.Hash) (*types.Receipt, error) {
-    rocketDepositPool, err := getRocketDepositPool(rp)
-    if err != nil {
-        return nil, err
-    }
-    return rocketDepositPool.WaitForTransaction(hash)
 }
 
 

--- a/deposit/deposit.go
+++ b/deposit/deposit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
@@ -64,6 +65,16 @@ func AssignDeposits(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.
         return common.Hash{}, fmt.Errorf("Could not assign deposits: %w", err)
     }
     return hash, nil
+}
+
+
+// Wait for a transaction to get mined
+func WaitForTransaction(rp *rocketpool.RocketPool, hash common.Hash) (*types.Receipt, error) {
+    rocketDepositPool, err := getRocketDepositPool(rp)
+    if err != nil {
+        return nil, err
+    }
+    return rocketDepositPool.WaitForTransaction(hash)
 }
 
 

--- a/deposit/deposit.go
+++ b/deposit/deposit.go
@@ -1,16 +1,15 @@
 package deposit
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Get the deposit pool balance
 func GetBalance(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int, error) {
@@ -41,30 +40,30 @@ func GetExcessBalance(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int,
 
 
 // Make a deposit
-func Deposit(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func Deposit(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDepositPool, err := getRocketDepositPool(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDepositPool.Transact(opts, "deposit")
+    hash, err := rocketDepositPool.Transact(opts, "deposit")
     if err != nil {
-        return nil, fmt.Errorf("Could not deposit: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not deposit: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Assign deposits
-func AssignDeposits(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func AssignDeposits(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.Hash, error) {
     rocketDepositPool, err := getRocketDepositPool(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketDepositPool.Transact(opts, "assignDeposits")
+    hash, err := rocketDepositPool.Transact(opts, "assignDeposits")
     if err != nil {
-        return nil, fmt.Errorf("Could not assign deposits: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not assign deposits: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/minipool/minipool-contract.go
+++ b/minipool/minipool-contract.go
@@ -1,21 +1,19 @@
 package minipool
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
-    "time"
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
-    "golang.org/x/sync/errgroup"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/sync/errgroup"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    rptypes "github.com/rocket-pool/rocketpool-go/types"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	rptypes "github.com/rocket-pool/rocketpool-go/types"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 // Minipool detail types
 type StatusDetails struct {
@@ -380,52 +378,52 @@ func (mp *Minipool) GetWithdrawalCredentials(opts *bind.CallOpts) (common.Hash, 
 
 
 // Refund node ETH from the minipool
-func (mp *Minipool) Refund(opts *bind.TransactOpts) (*types.Receipt, error) {
-    txReceipt, err := mp.Contract.Transact(opts, "refund")
+func (mp *Minipool) Refund(opts *bind.TransactOpts) (common.Hash, error) {
+    hash, err := mp.Contract.Transact(opts, "refund")
     if err != nil {
-        return nil, fmt.Errorf("Could not refund from minipool %s: %w", mp.Address.Hex(), err)
+        return common.Hash{}, fmt.Errorf("Could not refund from minipool %s: %w", mp.Address.Hex(), err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Progress the prelaunch minipool to staking
-func (mp *Minipool) Stake(validatorPubkey rptypes.ValidatorPubkey, validatorSignature rptypes.ValidatorSignature, depositDataRoot common.Hash, opts *bind.TransactOpts) (*types.Receipt, error) {
-    txReceipt, err := mp.Contract.Transact(opts, "stake", validatorPubkey[:], validatorSignature[:], depositDataRoot)
+func (mp *Minipool) Stake(validatorPubkey rptypes.ValidatorPubkey, validatorSignature rptypes.ValidatorSignature, depositDataRoot common.Hash, opts *bind.TransactOpts) (common.Hash, error) {
+    hash, err := mp.Contract.Transact(opts, "stake", validatorPubkey[:], validatorSignature[:], depositDataRoot)
     if err != nil {
-        return nil, fmt.Errorf("Could not stake minipool %s: %w", mp.Address.Hex(), err)
+        return common.Hash{}, fmt.Errorf("Could not stake minipool %s: %w", mp.Address.Hex(), err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Withdraw node balances & rewards from the withdrawable minipool and close it
-func (mp *Minipool) Withdraw(opts *bind.TransactOpts) (*types.Receipt, error) {
-    txReceipt, err := mp.Contract.Transact(opts, "withdraw")
+func (mp *Minipool) Withdraw(opts *bind.TransactOpts) (common.Hash, error) {
+    hash, err := mp.Contract.Transact(opts, "withdraw")
     if err != nil {
-        return nil, fmt.Errorf("Could not withdraw from minipool %s: %w", mp.Address.Hex(), err)
+        return common.Hash{}, fmt.Errorf("Could not withdraw from minipool %s: %w", mp.Address.Hex(), err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Dissolve the initialized or prelaunch minipool
-func (mp *Minipool) Dissolve(opts *bind.TransactOpts) (*types.Receipt, error) {
-    txReceipt, err := mp.Contract.Transact(opts, "dissolve")
+func (mp *Minipool) Dissolve(opts *bind.TransactOpts) (common.Hash, error) {
+    hash, err := mp.Contract.Transact(opts, "dissolve")
     if err != nil {
-        return nil, fmt.Errorf("Could not dissolve minipool %s: %w", mp.Address.Hex(), err)
+        return common.Hash{}, fmt.Errorf("Could not dissolve minipool %s: %w", mp.Address.Hex(), err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Withdraw node balances from the dissolved minipool and close it
-func (mp *Minipool) Close(opts *bind.TransactOpts) (*types.Receipt, error) {
-    txReceipt, err := mp.Contract.Transact(opts, "close")
+func (mp *Minipool) Close(opts *bind.TransactOpts) (common.Hash, error) {
+    hash, err := mp.Contract.Transact(opts, "close")
     if err != nil {
-        return nil, fmt.Errorf("Could not close minipool %s: %w", mp.Address.Hex(), err)
+        return common.Hash{}, fmt.Errorf("Could not close minipool %s: %w", mp.Address.Hex(), err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/minipool/minipool.go
+++ b/minipool/minipool.go
@@ -1,18 +1,18 @@
 package minipool
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "golang.org/x/sync/errgroup"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"golang.org/x/sync/errgroup"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    rptypes "github.com/rocket-pool/rocketpool-go/types"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	rptypes "github.com/rocket-pool/rocketpool-go/types"
 )
-
 
 // Settings
 const (
@@ -457,6 +457,16 @@ func GetMinipoolWithdrawalProcessed(rp *rocketpool.RocketPool, minipoolAddress c
         return false, fmt.Errorf("Could not get minipool %s withdrawal processed status: %w", minipoolAddress.Hex(), err)
     }
     return *processed, nil
+}
+
+
+// Wait for a transaction to get mined
+func WaitForTransaction(rp *rocketpool.RocketPool, hash common.Hash) (*types.Receipt, error) {
+    rocketMinipoolManager, err := getRocketMinipoolManager(rp)
+    if err != nil {
+        return nil, err
+    }
+    return rocketMinipoolManager.WaitForTransaction(hash)
 }
 
 

--- a/minipool/minipool.go
+++ b/minipool/minipool.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
@@ -457,16 +456,6 @@ func GetMinipoolWithdrawalProcessed(rp *rocketpool.RocketPool, minipoolAddress c
         return false, fmt.Errorf("Could not get minipool %s withdrawal processed status: %w", minipoolAddress.Hex(), err)
     }
     return *processed, nil
-}
-
-
-// Wait for a transaction to get mined
-func WaitForTransaction(rp *rocketpool.RocketPool, hash common.Hash) (*types.Receipt, error) {
-    rocketMinipoolManager, err := getRocketMinipoolManager(rp)
-    if err != nil {
-        return nil, err
-    }
-    return rocketMinipoolManager.WaitForTransaction(hash)
 }
 
 

--- a/minipool/status.go
+++ b/minipool/status.go
@@ -1,18 +1,16 @@
 package minipool
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 // Get the node reward amount for a minipool by node fee, user deposit balance, and staking start & end balances
 func GetMinipoolNodeRewardAmount(rp *rocketpool.RocketPool, nodeFee float64, userDepositBalance, startBalance, endBalance *big.Int, opts *bind.CallOpts) (*big.Int, error) {
@@ -29,16 +27,16 @@ func GetMinipoolNodeRewardAmount(rp *rocketpool.RocketPool, nodeFee float64, use
 
 
 // Submit a minipool withdrawable event
-func SubmitMinipoolWithdrawable(rp *rocketpool.RocketPool, minipoolAddress common.Address, stakingStartBalance, stakingEndBalance *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func SubmitMinipoolWithdrawable(rp *rocketpool.RocketPool, minipoolAddress common.Address, stakingStartBalance, stakingEndBalance *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketMinipoolStatus, err := getRocketMinipoolStatus(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketMinipoolStatus.Transact(opts, "submitMinipoolWithdrawable", minipoolAddress, stakingStartBalance, stakingEndBalance)
+    hash, err := rocketMinipoolStatus.Transact(opts, "submitMinipoolWithdrawable", minipoolAddress, stakingStartBalance, stakingEndBalance)
     if err != nil {
-        return nil, fmt.Errorf("Could not submit minipool withdrawable event: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not submit minipool withdrawable event: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/network/balances.go
+++ b/network/balances.go
@@ -1,17 +1,16 @@
 package network
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 // Get the block number which network balances are current for
 func GetBalancesBlock(rp *rocketpool.RocketPool, opts *bind.CallOpts) (uint64, error) {
@@ -84,16 +83,16 @@ func GetETHUtilizationRate(rp *rocketpool.RocketPool, opts *bind.CallOpts) (floa
 
 
 // Submit network balances for an epoch
-func SubmitBalances(rp *rocketpool.RocketPool, block uint64, totalEth, stakingEth, rethSupply *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func SubmitBalances(rp *rocketpool.RocketPool, block uint64, totalEth, stakingEth, rethSupply *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketNetworkBalances, err := getRocketNetworkBalances(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketNetworkBalances.Transact(opts, "submitBalances", big.NewInt(int64(block)), totalEth, stakingEth, rethSupply)
+    hash, err := rocketNetworkBalances.Transact(opts, "submitBalances", big.NewInt(int64(block)), totalEth, stakingEth, rethSupply)
     if err != nil {
-        return nil, fmt.Errorf("Could not submit network balances: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not submit network balances: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/network/prices.go
+++ b/network/prices.go
@@ -1,16 +1,15 @@
 package network
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Get the block number which network prices are current for
 func GetPricesBlock(rp *rocketpool.RocketPool, opts *bind.CallOpts) (uint64, error) {
@@ -41,16 +40,16 @@ func GetRPLPrice(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int, erro
 
 
 // Submit network prices for an epoch
-func SubmitPrices(rp *rocketpool.RocketPool, block uint64, rplPrice *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func SubmitPrices(rp *rocketpool.RocketPool, block uint64, rplPrice *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketNetworkPrices, err := getRocketNetworkPrices(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketNetworkPrices.Transact(opts, "submitPrices", big.NewInt(int64(block)), rplPrice)
+    hash, err := rocketNetworkPrices.Transact(opts, "submitPrices", big.NewInt(int64(block)), rplPrice)
     if err != nil {
-        return nil, fmt.Errorf("Could not submit network prices: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not submit network prices: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/node/deposit.go
+++ b/node/deposit.go
@@ -1,28 +1,27 @@
 package node
 
 import (
-    "fmt"
-    "sync"
+	"fmt"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
 
-
 // Make a node deposit
-func Deposit(rp *rocketpool.RocketPool, minimumNodeFee float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func Deposit(rp *rocketpool.RocketPool, minimumNodeFee float64, opts *bind.TransactOpts) (common.Hash, error) {
     rocketNodeDeposit, err := getRocketNodeDeposit(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketNodeDeposit.Transact(opts, "deposit", eth.EthToWei(minimumNodeFee))
+    hash, err := rocketNodeDeposit.Transact(opts, "deposit", eth.EthToWei(minimumNodeFee))
     if err != nil {
-        return nil, fmt.Errorf("Could not make node deposit: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not make node deposit: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/node/node.go
+++ b/node/node.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
@@ -262,16 +261,6 @@ func SetTimezoneLocation(rp *rocketpool.RocketPool, timezoneLocation string, opt
         return common.Hash{}, fmt.Errorf("Could not set node timezone location: %w", err)
     }
     return hash, nil
-}
-
-
-// Wait for a transaction to get mined
-func WaitForTransaction(rp *rocketpool.RocketPool, hash common.Hash) (*types.Receipt, error) {
-    rocketNodeManager, err := getRocketNodeManager(rp)
-    if err != nil {
-        return nil, err
-    }
-    return rocketNodeManager.WaitForTransaction(hash)
 }
 
 

--- a/node/node.go
+++ b/node/node.go
@@ -1,19 +1,18 @@
 package node
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
-    "golang.org/x/sync/errgroup"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"golang.org/x/sync/errgroup"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/strings"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/strings"
 )
-
 
 // Settings
 const (
@@ -225,44 +224,54 @@ func GetNodeTimezoneLocation(rp *rocketpool.RocketPool, nodeAddress common.Addre
 
 
 // Register a node
-func RegisterNode(rp *rocketpool.RocketPool, timezoneLocation string, opts *bind.TransactOpts) (*types.Receipt, error) {
+func RegisterNode(rp *rocketpool.RocketPool, timezoneLocation string, opts *bind.TransactOpts) (common.Hash, error) {
     rocketNodeManager, err := getRocketNodeManager(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketNodeManager.Transact(opts, "registerNode", timezoneLocation)
+    hash, err := rocketNodeManager.Transact(opts, "registerNode", timezoneLocation)
     if err != nil {
-        return nil, fmt.Errorf("Could not register node: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not register node: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Set a node's withdrawal address
-func SetWithdrawalAddress(rp *rocketpool.RocketPool, withdrawalAddress common.Address, opts *bind.TransactOpts) (*types.Receipt, error) {
+func SetWithdrawalAddress(rp *rocketpool.RocketPool, withdrawalAddress common.Address, opts *bind.TransactOpts) (common.Hash, error) {
     rocketNodeManager, err := getRocketNodeManager(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketNodeManager.Transact(opts, "setWithdrawalAddress", withdrawalAddress)
+    hash, err := rocketNodeManager.Transact(opts, "setWithdrawalAddress", withdrawalAddress)
     if err != nil {
-        return nil, fmt.Errorf("Could not set node withdrawal address: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not set node withdrawal address: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Set a node's timezone location
-func SetTimezoneLocation(rp *rocketpool.RocketPool, timezoneLocation string, opts *bind.TransactOpts) (*types.Receipt, error) {
+func SetTimezoneLocation(rp *rocketpool.RocketPool, timezoneLocation string, opts *bind.TransactOpts) (common.Hash, error) {
+    rocketNodeManager, err := getRocketNodeManager(rp)
+    if err != nil {
+        return common.Hash{}, err
+    }
+    hash, err := rocketNodeManager.Transact(opts, "setTimezoneLocation", timezoneLocation)
+    if err != nil {
+        return common.Hash{}, fmt.Errorf("Could not set node timezone location: %w", err)
+    }
+    return hash, nil
+}
+
+
+// Wait for a transaction to get mined
+func WaitForTransaction(rp *rocketpool.RocketPool, hash common.Hash) (*types.Receipt, error) {
     rocketNodeManager, err := getRocketNodeManager(rp)
     if err != nil {
         return nil, err
     }
-    txReceipt, err := rocketNodeManager.Transact(opts, "setTimezoneLocation", timezoneLocation)
-    if err != nil {
-        return nil, fmt.Errorf("Could not set node timezone location: %w", err)
-    }
-    return txReceipt, nil
+    return rocketNodeManager.WaitForTransaction(hash)
 }
 
 

--- a/node/staking.go
+++ b/node/staking.go
@@ -1,17 +1,15 @@
 package node
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Get the total RPL staked in the network
 func GetTotalRPLStake(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int, error) {
@@ -112,30 +110,30 @@ func GetNodeMinipoolLimit(rp *rocketpool.RocketPool, nodeAddress common.Address,
 
 
 // Stake RPL
-func StakeRPL(rp *rocketpool.RocketPool, rplAmount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func StakeRPL(rp *rocketpool.RocketPool, rplAmount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketNodeStaking, err := getRocketNodeStaking(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketNodeStaking.Transact(opts, "stakeRPL", rplAmount)
+    hash, err := rocketNodeStaking.Transact(opts, "stakeRPL", rplAmount)
     if err != nil {
-        return nil, fmt.Errorf("Could not stake RPL: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not stake RPL: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Withdraw staked RPL
-func WithdrawRPL(rp *rocketpool.RocketPool, rplAmount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func WithdrawRPL(rp *rocketpool.RocketPool, rplAmount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketNodeStaking, err := getRocketNodeStaking(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketNodeStaking.Transact(opts, "withdrawRPL", rplAmount)
+    hash, err := rocketNodeStaking.Transact(opts, "withdrawRPL", rplAmount)
     if err != nil {
-        return nil, fmt.Errorf("Could not withdraw staked RPL: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not withdraw staked RPL: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/rewards/node.go
+++ b/rewards/node.go
@@ -1,16 +1,14 @@
 package rewards
 
 import (
-    "math/big"
-    "sync"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Get whether node reward claims are enabled
 func GetNodeClaimsEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts) (bool, error) {
@@ -53,10 +51,10 @@ func GetNodeClaimRewardsAmount(rp *rocketpool.RocketPool, claimerAddress common.
 
 
 // Claim node rewards
-func ClaimNodeRewards(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func ClaimNodeRewards(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.Hash, error) {
     rocketClaimNode, err := getRocketClaimNode(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return claim(rocketClaimNode, "node", opts)
 }

--- a/rewards/rewards.go
+++ b/rewards/rewards.go
@@ -1,17 +1,15 @@
 package rewards
 
 import (
-    "fmt"
-    "math/big"
+	"fmt"
+	"math/big"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 // Get whether a claims contract is enabled
 func getEnabled(claimsContract *rocketpool.Contract, claimsName string, opts *bind.CallOpts) (bool, error) {
@@ -56,11 +54,11 @@ func getClaimRewardsAmount(claimsContract *rocketpool.Contract, claimsName strin
 
 
 // Claim rewards
-func claim(claimsContract *rocketpool.Contract, claimsName string, opts *bind.TransactOpts) (*types.Receipt, error) {
-    txReceipt, err := claimsContract.Transact(opts, "claim")
+func claim(claimsContract *rocketpool.Contract, claimsName string, opts *bind.TransactOpts) (common.Hash, error) {
+    hash, err := claimsContract.Transact(opts, "claim")
     if err != nil {
-        return nil, fmt.Errorf("Could not claim %s rewards: %w", claimsName, err)
+        return common.Hash{}, fmt.Errorf("Could not claim %s rewards: %w", claimsName, err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 

--- a/rewards/trusted-node.go
+++ b/rewards/trusted-node.go
@@ -1,16 +1,14 @@
 package rewards
 
 import (
-    "math/big"
-    "sync"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Get whether trusted node reward claims are enabled
 func GetTrustedNodeClaimsEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts) (bool, error) {
@@ -53,10 +51,10 @@ func GetTrustedNodeClaimRewardsAmount(rp *rocketpool.RocketPool, claimerAddress 
 
 
 // Claim trusted node rewards
-func ClaimTrustedNodeRewards(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func ClaimTrustedNodeRewards(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.Hash, error) {
     rocketClaimTrustedNode, err := getRocketClaimTrustedNode(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return claim(rocketClaimTrustedNode, "trusted node", opts)
 }

--- a/rocketpool/contract.go
+++ b/rocketpool/contract.go
@@ -89,21 +89,6 @@ func (c *Contract) Transfer(opts *bind.TransactOpts) (common.Hash, error) {
 }
 
 
-// Block until a transaction is mined, then return the receipt
-func (c *Contract) WaitForTransaction(hash common.Hash) (*types.Receipt, error) {
-
-    // Get the transaction from its hash
-    tx, _, err := c.Client.TransactionByHash(context.Background(), hash)
-    if err != nil {
-        return nil, err
-    }
-
-    // Get & return transaction receipt
-    return c.getTransactionReceipt(tx)
-
-}
-
-
 // Estimate the gas limit for a contract transaction
 func (c *Contract) estimateGasLimit(opts *bind.TransactOpts, input []byte) (uint64, error) {
 

--- a/rocketpool/rocketpool.go
+++ b/rocketpool/rocketpool.go
@@ -1,20 +1,19 @@
 package rocketpool
 
 import (
-    "fmt"
-    "sync"
-    "time"
+	"fmt"
+	"sync"
+	"time"
 
-    "github.com/ethereum/go-ethereum/accounts/abi"
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/crypto"
-    "github.com/ethereum/go-ethereum/ethclient"
-    "golang.org/x/sync/errgroup"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"golang.org/x/sync/errgroup"
 
-    "github.com/rocket-pool/rocketpool-go/contracts"
+	"github.com/rocket-pool/rocketpool-go/contracts"
 )
-
 
 // Cache settings
 const CacheTTL = 300 // 5 minutes

--- a/settings/protocol/auction.go
+++ b/settings/protocol/auction.go
@@ -1,18 +1,17 @@
 package protocol
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 // Config
 const AuctionSettingsContractName = "rocketDAOProtocolSettingsAuction"
@@ -30,7 +29,7 @@ func GetCreateLotEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts) (bool, 
     }
     return *value, nil
 }
-func BootstrapCreateLotEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapCreateLotEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapBool(rp, AuctionSettingsContractName, "auction.lot.create.enabled", value, opts)
 }
 
@@ -47,7 +46,7 @@ func GetBidOnLotEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts) (bool, e
     }
     return *value, nil
 }
-func BootstrapBidOnLotEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapBidOnLotEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapBool(rp, AuctionSettingsContractName, "auction.lot.bidding.enabled", value, opts)
 }
 
@@ -64,7 +63,7 @@ func GetLotMinimumEthValue(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big
     }
     return *value, nil
 }
-func BootstrapLotMinimumEthValue(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapLotMinimumEthValue(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, AuctionSettingsContractName, "auction.lot.value.minimum", value, opts)
 }
 
@@ -81,7 +80,7 @@ func GetLotMaximumEthValue(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big
     }
     return *value, nil
 }
-func BootstrapLotMaximumEthValue(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapLotMaximumEthValue(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, AuctionSettingsContractName, "auction.lot.value.maximum", value, opts)
 }
 
@@ -98,7 +97,7 @@ func GetLotDuration(rp *rocketpool.RocketPool, opts *bind.CallOpts) (uint64, err
     }
     return (*value).Uint64(), nil
 }
-func BootstrapLotDuration(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapLotDuration(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, AuctionSettingsContractName, "auction.lot.duration", big.NewInt(int64(value)), opts)
 }
 
@@ -115,7 +114,7 @@ func GetLotStartingPriceRatio(rp *rocketpool.RocketPool, opts *bind.CallOpts) (f
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapLotStartingPriceRatio(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapLotStartingPriceRatio(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, AuctionSettingsContractName, "auction.price.start", eth.EthToWei(value), opts)
 }
 
@@ -132,7 +131,7 @@ func GetLotReservePriceRatio(rp *rocketpool.RocketPool, opts *bind.CallOpts) (fl
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapLotReservePriceRatio(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapLotReservePriceRatio(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, AuctionSettingsContractName, "auction.price.reserve", eth.EthToWei(value), opts)
 }
 

--- a/settings/protocol/deposit.go
+++ b/settings/protocol/deposit.go
@@ -1,17 +1,16 @@
 package protocol
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Config
 const DepositSettingsContractName = "rocketDAOProtocolSettingsDeposit"
@@ -29,7 +28,7 @@ func GetDepositEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts) (bool, er
     }
     return *value, nil
 }
-func BootstrapDepositEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapDepositEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapBool(rp, DepositSettingsContractName, "deposit.enabled", value, opts)
 }
 
@@ -46,7 +45,7 @@ func GetAssignDepositsEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts) (b
     }
     return *value, nil
 }
-func BootstrapAssignDepositsEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapAssignDepositsEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapBool(rp, DepositSettingsContractName, "deposit.assign.enabled", value, opts)
 }
 
@@ -63,7 +62,7 @@ func GetMinimumDeposit(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int
     }
     return *value, nil
 }
-func BootstrapMinimumDeposit(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMinimumDeposit(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, DepositSettingsContractName, "deposit.minimum", value, opts)
 }
 
@@ -80,7 +79,7 @@ func GetMaximumDepositPoolSize(rp *rocketpool.RocketPool, opts *bind.CallOpts) (
     }
     return *value, nil
 }
-func BootstrapMaximumDepositPoolSize(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMaximumDepositPoolSize(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, DepositSettingsContractName, "deposit.pool.maximum", value, opts)
 }
 
@@ -97,7 +96,7 @@ func GetMaximumDepositAssignments(rp *rocketpool.RocketPool, opts *bind.CallOpts
     }
     return (*value).Uint64(), nil
 }
-func BootstrapMaximumDepositAssignments(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMaximumDepositAssignments(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, DepositSettingsContractName, "deposit.assign.maximum", big.NewInt(int64(value)), opts)
 }
 

--- a/settings/protocol/inflation.go
+++ b/settings/protocol/inflation.go
@@ -1,18 +1,17 @@
 package protocol
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 // Config
 const InflationSettingsContractName = "rocketDAOProtocolSettingsInflation"
@@ -30,7 +29,7 @@ func GetInflationIntervalRate(rp *rocketpool.RocketPool, opts *bind.CallOpts) (f
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapInflationIntervalRate(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapInflationIntervalRate(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, InflationSettingsContractName, "rpl.inflation.interval.rate", eth.EthToWei(value), opts)
 }
 
@@ -47,7 +46,7 @@ func GetInflationIntervalBlocks(rp *rocketpool.RocketPool, opts *bind.CallOpts) 
     }
     return (*value).Uint64(), nil
 }
-func BootstrapInflationIntervalBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapInflationIntervalBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, InflationSettingsContractName, "rpl.inflation.interval.blocks", big.NewInt(int64(value)), opts)
 }
 
@@ -64,7 +63,7 @@ func GetInflationStartBlock(rp *rocketpool.RocketPool, opts *bind.CallOpts) (uin
     }
     return (*value).Uint64(), nil
 }
-func BootstrapInflationStartBlock(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapInflationStartBlock(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, InflationSettingsContractName, "rpl.inflation.interval.start", big.NewInt(int64(value)), opts)
 }
 

--- a/settings/protocol/minipool.go
+++ b/settings/protocol/minipool.go
@@ -1,17 +1,16 @@
 package protocol
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Config
 const MinipoolSettingsContractName = "rocketDAOProtocolSettingsMinipool"
@@ -115,7 +114,7 @@ func GetMinipoolSubmitWithdrawableEnabled(rp *rocketpool.RocketPool, opts *bind.
     }
     return *value, nil
 }
-func BootstrapMinipoolSubmitWithdrawableEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMinipoolSubmitWithdrawableEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapBool(rp, MinipoolSettingsContractName, "minipool.submit.withdrawable.enabled", value, opts)
 }
 
@@ -132,7 +131,7 @@ func GetMinipoolLaunchTimeout(rp *rocketpool.RocketPool, opts *bind.CallOpts) (u
     }
     return (*value).Uint64(), nil
 }
-func BootstrapMinipoolLaunchTimeout(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMinipoolLaunchTimeout(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, MinipoolSettingsContractName, "minipool.launch.timeout", big.NewInt(int64(value)), opts)
 }
 
@@ -149,7 +148,7 @@ func GetMinipoolWithdrawalDelay(rp *rocketpool.RocketPool, opts *bind.CallOpts) 
     }
     return (*value).Uint64(), nil
 }
-func BootstrapMinipoolWithdrawalDelay(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMinipoolWithdrawalDelay(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, MinipoolSettingsContractName, "minipool.withdrawal.delay", big.NewInt(int64(value)), opts)
 }
 

--- a/settings/protocol/network.go
+++ b/settings/protocol/network.go
@@ -1,19 +1,17 @@
 package protocol
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 // Config
 const NetworkSettingsContractName = "rocketDAOProtocolSettingsNetwork"
@@ -31,7 +29,7 @@ func GetNodeConsensusThreshold(rp *rocketpool.RocketPool, opts *bind.CallOpts) (
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapNodeConsensusThreshold(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapNodeConsensusThreshold(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, NetworkSettingsContractName, "network.consensus.threshold", eth.EthToWei(value), opts)
 }
 
@@ -48,7 +46,7 @@ func GetSubmitBalancesEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts) (b
     }
     return *value, nil
 }
-func BootstrapSubmitBalancesEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapSubmitBalancesEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapBool(rp, NetworkSettingsContractName, "network.submit.balances.enabled", value, opts)
 }
 
@@ -65,7 +63,7 @@ func GetSubmitBalancesFrequency(rp *rocketpool.RocketPool, opts *bind.CallOpts) 
     }
     return (*value).Uint64(), nil
 }
-func BootstrapSubmitBalancesFrequency(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapSubmitBalancesFrequency(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, NetworkSettingsContractName, "network.submit.balances.frequency", big.NewInt(int64(value)), opts)
 }
 
@@ -82,7 +80,7 @@ func GetSubmitPricesEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts) (boo
     }
     return *value, nil
 }
-func BootstrapSubmitPricesEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapSubmitPricesEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapBool(rp, NetworkSettingsContractName, "network.submit.prices.enabled", value, opts)
 }
 
@@ -99,7 +97,7 @@ func GetSubmitPricesFrequency(rp *rocketpool.RocketPool, opts *bind.CallOpts) (u
     }
     return (*value).Uint64(), nil
 }
-func BootstrapSubmitPricesFrequency(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapSubmitPricesFrequency(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, NetworkSettingsContractName, "network.submit.prices.frequency", big.NewInt(int64(value)), opts)
 }
 
@@ -116,7 +114,7 @@ func GetProcessWithdrawalsEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts
     }
     return *value, nil
 }
-func BootstrapProcessWithdrawalsEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapProcessWithdrawalsEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapBool(rp, NetworkSettingsContractName, "network.process.withdrawals.enabled", value, opts)
 }
 
@@ -133,7 +131,7 @@ func GetMinimumNodeFee(rp *rocketpool.RocketPool, opts *bind.CallOpts) (float64,
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapMinimumNodeFee(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMinimumNodeFee(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, NetworkSettingsContractName, "network.node.fee.minimum", eth.EthToWei(value), opts)
 }
 
@@ -150,7 +148,7 @@ func GetTargetNodeFee(rp *rocketpool.RocketPool, opts *bind.CallOpts) (float64, 
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapTargetNodeFee(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapTargetNodeFee(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, NetworkSettingsContractName, "network.node.fee.target", eth.EthToWei(value), opts)
 }
 
@@ -167,7 +165,7 @@ func GetMaximumNodeFee(rp *rocketpool.RocketPool, opts *bind.CallOpts) (float64,
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapMaximumNodeFee(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMaximumNodeFee(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, NetworkSettingsContractName, "network.node.fee.maximum", eth.EthToWei(value), opts)
 }
 
@@ -184,7 +182,7 @@ func GetNodeFeeDemandRange(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big
     }
     return *value, nil
 }
-func BootstrapNodeFeeDemandRange(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapNodeFeeDemandRange(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, NetworkSettingsContractName, "network.node.fee.demand.range", value, opts)
 }
 
@@ -201,7 +199,7 @@ func GetTargetRethCollateralRate(rp *rocketpool.RocketPool, opts *bind.CallOpts)
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapTargetRethCollateralRate(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapTargetRethCollateralRate(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, NetworkSettingsContractName, "network.reth.collateral.target", eth.EthToWei(value), opts)
 }
 
@@ -218,7 +216,7 @@ func GetSystemWithdrawalContractAddress(rp *rocketpool.RocketPool, opts *bind.Ca
     }
     return *value, nil
 }
-func BootstrapSystemWithdrawalContractAddress(rp *rocketpool.RocketPool, value common.Address, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapSystemWithdrawalContractAddress(rp *rocketpool.RocketPool, value common.Address, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapAddress(rp, NetworkSettingsContractName, "network.withdrawal.contract.address", value, opts)
 }
 

--- a/settings/protocol/node.go
+++ b/settings/protocol/node.go
@@ -1,18 +1,17 @@
 package protocol
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 // Config
 const NodeSettingsContractName = "rocketDAOProtocolSettingsNode"
@@ -30,7 +29,7 @@ func GetNodeRegistrationEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts) 
     }
     return *value, nil
 }
-func BootstrapNodeRegistrationEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapNodeRegistrationEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapBool(rp, NodeSettingsContractName, "node.registration.enabled", value, opts)
 }
 
@@ -47,7 +46,7 @@ func GetNodeDepositEnabled(rp *rocketpool.RocketPool, opts *bind.CallOpts) (bool
     }
     return *value, nil
 }
-func BootstrapNodeDepositEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapNodeDepositEnabled(rp *rocketpool.RocketPool, value bool, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapBool(rp, NodeSettingsContractName, "node.deposit.enabled", value, opts)
 }
 
@@ -64,7 +63,7 @@ func GetMinimumPerMinipoolStake(rp *rocketpool.RocketPool, opts *bind.CallOpts) 
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapMinimumPerMinipoolStake(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMinimumPerMinipoolStake(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, NodeSettingsContractName, "node.per.minipool.stake.minimum", eth.EthToWei(value), opts)
 }
 
@@ -81,7 +80,7 @@ func GetMaximumPerMinipoolStake(rp *rocketpool.RocketPool, opts *bind.CallOpts) 
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapMaximumPerMinipoolStake(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMaximumPerMinipoolStake(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, NodeSettingsContractName, "node.per.minipool.stake.maximum", eth.EthToWei(value), opts)
 }
 

--- a/settings/protocol/rewards.go
+++ b/settings/protocol/rewards.go
@@ -1,18 +1,17 @@
 package protocol
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	protocoldao "github.com/rocket-pool/rocketpool-go/dao/protocol"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 // Config
 const RewardsSettingsContractName = "rocketDAOProtocolSettingsRewards"
@@ -72,7 +71,7 @@ func GetRewardsClaimIntervalBlocks(rp *rocketpool.RocketPool, opts *bind.CallOpt
     }
     return (*value).Uint64(), nil
 }
-func BootstrapRewardsClaimIntervalBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapRewardsClaimIntervalBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return protocoldao.BootstrapUint(rp, RewardsSettingsContractName, "rpl.rewards.claim.period.blocks", big.NewInt(int64(value)), opts)
 }
 

--- a/settings/trustednode/members.go
+++ b/settings/trustednode/members.go
@@ -1,18 +1,17 @@
 package trustednode
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    trustednodedao "github.com/rocket-pool/rocketpool-go/dao/trustednode"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	trustednodedao "github.com/rocket-pool/rocketpool-go/dao/trustednode"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 // Config
 const (
@@ -38,10 +37,10 @@ func GetQuorum(rp *rocketpool.RocketPool, opts *bind.CallOpts) (float64, error) 
     }
     return eth.WeiToEth(*value), nil
 }
-func BootstrapQuorum(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapQuorum(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, MembersSettingsContractName, QuorumSettingPath, eth.EthToWei(value), opts)
 }
-func ProposeQuorum(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeQuorum(rp *rocketpool.RocketPool, value float64, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", QuorumSettingPath), MembersSettingsContractName, QuorumSettingPath, eth.EthToWei(value), opts)
 }
 
@@ -58,10 +57,10 @@ func GetRPLBond(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int, error
     }
     return *value, nil
 }
-func BootstrapRPLBond(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapRPLBond(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, MembersSettingsContractName, RPLBondSettingPath, value, opts)
 }
-func ProposeRPLBond(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeRPLBond(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", RPLBondSettingPath), MembersSettingsContractName, RPLBondSettingPath, value, opts)
 }
 
@@ -78,10 +77,10 @@ func GetMinipoolUnbondedMax(rp *rocketpool.RocketPool, opts *bind.CallOpts) (uin
     }
     return (*value).Uint64(), nil
 }
-func BootstrapMinipoolUnbondedMax(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapMinipoolUnbondedMax(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, MembersSettingsContractName, MinipoolUnbondedMaxSettingPath, big.NewInt(int64(value)), opts)
 }
-func ProposeMinipoolUnbondedMax(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeMinipoolUnbondedMax(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", MinipoolUnbondedMaxSettingPath), MembersSettingsContractName, MinipoolUnbondedMaxSettingPath, big.NewInt(int64(value)), opts)
 }
 
@@ -98,10 +97,10 @@ func GetChallengeCooldown(rp *rocketpool.RocketPool, opts *bind.CallOpts) (uint6
     }
     return (*value).Uint64(), nil
 }
-func BootstrapChallengeCooldown(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapChallengeCooldown(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, MembersSettingsContractName, ChallengeCooldownSettingPath, big.NewInt(int64(value)), opts)
 }
-func ProposeChallengeCooldown(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeChallengeCooldown(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", ChallengeCooldownSettingPath), MembersSettingsContractName, ChallengeCooldownSettingPath, big.NewInt(int64(value)), opts)
 }
 
@@ -118,10 +117,10 @@ func GetChallengeWindow(rp *rocketpool.RocketPool, opts *bind.CallOpts) (uint64,
     }
     return (*value).Uint64(), nil
 }
-func BootstrapChallengeWindow(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapChallengeWindow(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, MembersSettingsContractName, ChallengeWindowSettingPath, big.NewInt(int64(value)), opts)
 }
-func ProposeChallengeWindow(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeChallengeWindow(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", ChallengeWindowSettingPath), MembersSettingsContractName, ChallengeWindowSettingPath, big.NewInt(int64(value)), opts)
 }
 
@@ -138,10 +137,10 @@ func GetChallengeCost(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int,
     }
     return *value, nil
 }
-func BootstrapChallengeCost(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapChallengeCost(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, MembersSettingsContractName, ChallengeCostSettingPath, value, opts)
 }
-func ProposeChallengeCost(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeChallengeCost(rp *rocketpool.RocketPool, value *big.Int, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", ChallengeCostSettingPath), MembersSettingsContractName, ChallengeCostSettingPath, value, opts)
 }
 

--- a/settings/trustednode/proposals.go
+++ b/settings/trustednode/proposals.go
@@ -1,17 +1,16 @@
 package trustednode
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    trustednodedao "github.com/rocket-pool/rocketpool-go/dao/trustednode"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	trustednodedao "github.com/rocket-pool/rocketpool-go/dao/trustednode"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Config
 const (
@@ -36,10 +35,10 @@ func GetProposalCooldown(rp *rocketpool.RocketPool, opts *bind.CallOpts) (uint64
     }
     return (*value).Uint64(), nil
 }
-func BootstrapProposalCooldown(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapProposalCooldown(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, ProposalsSettingsContractName, CooldownSettingPath, big.NewInt(int64(value)), opts)
 }
-func ProposeProposalCooldown(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeProposalCooldown(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", CooldownSettingPath), ProposalsSettingsContractName, CooldownSettingPath, big.NewInt(int64(value)), opts)
 }
 
@@ -56,10 +55,10 @@ func GetProposalVoteBlocks(rp *rocketpool.RocketPool, opts *bind.CallOpts) (uint
     }
     return (*value).Uint64(), nil
 }
-func BootstrapProposalVoteBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapProposalVoteBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, ProposalsSettingsContractName, VoteBlocksSettingPath, big.NewInt(int64(value)), opts)
 }
-func ProposeProposalVoteBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeProposalVoteBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", VoteBlocksSettingPath), ProposalsSettingsContractName, VoteBlocksSettingPath, big.NewInt(int64(value)), opts)
 }
 
@@ -76,10 +75,10 @@ func GetProposalVoteDelayBlocks(rp *rocketpool.RocketPool, opts *bind.CallOpts) 
     }
     return (*value).Uint64(), nil
 }
-func BootstrapProposalVoteDelayBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapProposalVoteDelayBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, ProposalsSettingsContractName, VoteDelayBlocksSettingPath, big.NewInt(int64(value)), opts)
 }
-func ProposeProposalVoteDelayBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeProposalVoteDelayBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", VoteDelayBlocksSettingPath), ProposalsSettingsContractName, VoteDelayBlocksSettingPath, big.NewInt(int64(value)), opts)
 }
 
@@ -96,10 +95,10 @@ func GetProposalExecuteBlocks(rp *rocketpool.RocketPool, opts *bind.CallOpts) (u
     }
     return (*value).Uint64(), nil
 }
-func BootstrapProposalExecuteBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapProposalExecuteBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, ProposalsSettingsContractName, ExecuteBlocksSettingPath, big.NewInt(int64(value)), opts)
 }
-func ProposeProposalExecuteBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeProposalExecuteBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", ExecuteBlocksSettingPath), ProposalsSettingsContractName, ExecuteBlocksSettingPath, big.NewInt(int64(value)), opts)
 }
 
@@ -116,10 +115,10 @@ func GetProposalActionBlocks(rp *rocketpool.RocketPool, opts *bind.CallOpts) (ui
     }
     return (*value).Uint64(), nil
 }
-func BootstrapProposalActionBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BootstrapProposalActionBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (common.Hash, error) {
     return trustednodedao.BootstrapUint(rp, ProposalsSettingsContractName, ActionBlocksSettingPath, big.NewInt(int64(value)), opts)
 }
-func ProposeProposalActionBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, *types.Receipt, error) {
+func ProposeProposalActionBlocks(rp *rocketpool.RocketPool, value uint64, opts *bind.TransactOpts) (uint64, common.Hash, error) {
     return trustednodedao.ProposeSetUint(rp, fmt.Sprintf("set %s", ActionBlocksSettingPath), ProposalsSettingsContractName, ActionBlocksSettingPath, big.NewInt(int64(value)), opts)
 }
 

--- a/tests/testutils/minipool/minipool.go
+++ b/tests/testutils/minipool/minipool.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rocket-pool/rocketpool-go/node"
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
 	"github.com/rocket-pool/rocketpool-go/settings/protocol"
+	"github.com/rocket-pool/rocketpool-go/utils"
 	"github.com/rocket-pool/rocketpool-go/utils/eth"
 
 	"github.com/rocket-pool/rocketpool-go/tests/testutils/accounts"
@@ -39,7 +40,7 @@ func CreateMinipool(rp *rocketpool.RocketPool, ownerAccount, nodeAccount *accoun
     opts.Value = depositAmount
     hash, err := node.Deposit(rp, 0, opts)
     if err != nil { return nil, err }
-    txReceipt, err := node.WaitForTransaction(rp, hash)
+    txReceipt, err := utils.WaitForTransaction(rp.Client, hash)
     if err != nil { return nil, err }
 
     // Get minipool manager contract

--- a/tests/testutils/minipool/minipool.go
+++ b/tests/testutils/minipool/minipool.go
@@ -1,23 +1,22 @@
 package minipool
 
 import (
-    "errors"
-    "math/big"
+	"errors"
+	"math/big"
 
-    "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/minipool"
-    "github.com/rocket-pool/rocketpool-go/network"
-    "github.com/rocket-pool/rocketpool-go/node"
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/settings/protocol"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	"github.com/rocket-pool/rocketpool-go/minipool"
+	"github.com/rocket-pool/rocketpool-go/network"
+	"github.com/rocket-pool/rocketpool-go/node"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/settings/protocol"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 
-    "github.com/rocket-pool/rocketpool-go/tests/testutils/accounts"
-    nodeutils "github.com/rocket-pool/rocketpool-go/tests/testutils/node"
-    "github.com/rocket-pool/rocketpool-go/tests/testutils/validator"
+	"github.com/rocket-pool/rocketpool-go/tests/testutils/accounts"
+	nodeutils "github.com/rocket-pool/rocketpool-go/tests/testutils/node"
+	"github.com/rocket-pool/rocketpool-go/tests/testutils/validator"
 )
-
 
 // Minipool created event
 type minipoolCreated struct {
@@ -38,7 +37,9 @@ func CreateMinipool(rp *rocketpool.RocketPool, ownerAccount, nodeAccount *accoun
     // Make node deposit
     opts := nodeAccount.GetTransactor()
     opts.Value = depositAmount
-    txReceipt, err := node.Deposit(rp, 0, opts)
+    hash, err := node.Deposit(rp, 0, opts)
+    if err != nil { return nil, err }
+    txReceipt, err := node.WaitForTransaction(rp, hash)
     if err != nil { return nil, err }
 
     // Get minipool manager contract

--- a/tests/utils/eth/transactions_test.go
+++ b/tests/utils/eth/transactions_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rocket-pool/rocketpool-go/tests"
 	"github.com/rocket-pool/rocketpool-go/tests/testutils/accounts"
 	"github.com/rocket-pool/rocketpool-go/tests/testutils/evm"
+	"github.com/rocket-pool/rocketpool-go/utils"
 )
 
 
@@ -40,7 +41,7 @@ func TestSendTransaction(t *testing.T) {
     if err != nil {
         t.Fatal(err)
     }
-    if _, err := eth.WaitForSendTransaction(client, hash); err != nil {
+    if _, err := utils.WaitForTransaction(client, hash); err != nil {
         t.Fatal(err)
     }
 

--- a/tests/utils/eth/transactions_test.go
+++ b/tests/utils/eth/transactions_test.go
@@ -1,17 +1,17 @@
 package eth
 
 import (
-    "context"
-    "testing"
+	"context"
+	"testing"
 
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 
-    "github.com/rocket-pool/rocketpool-go/tests"
-    "github.com/rocket-pool/rocketpool-go/tests/testutils/accounts"
-    "github.com/rocket-pool/rocketpool-go/tests/testutils/evm"
+	"github.com/rocket-pool/rocketpool-go/tests"
+	"github.com/rocket-pool/rocketpool-go/tests/testutils/accounts"
+	"github.com/rocket-pool/rocketpool-go/tests/testutils/evm"
 )
 
 
@@ -36,7 +36,11 @@ func TestSendTransaction(t *testing.T) {
     // Send transaction
     opts := userAccount.GetTransactor()
     opts.Value = sendAmount
-    if _, err := eth.SendTransaction(client, toAddress, opts); err != nil {
+    hash, err := eth.SendTransaction(client, toAddress, opts)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if _, err := eth.WaitForSendTransaction(client, hash); err != nil {
         t.Fatal(err)
     }
 

--- a/tokens/neth.go
+++ b/tokens/neth.go
@@ -1,22 +1,19 @@
 package tokens
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 //
 // Core ERC-20 functions
 //
-
 
 // Get nETH total supply
 func GetNETHTotalSupply(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int, error) {
@@ -49,30 +46,30 @@ func GetNETHAllowance(rp *rocketpool.RocketPool, owner, spender common.Address, 
 
 
 // Transfer nETH
-func TransferNETH(rp *rocketpool.RocketPool, to common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func TransferNETH(rp *rocketpool.RocketPool, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenNETH, err := getRocketTokenNETH(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return transfer(rocketTokenNETH, "nETH", to, amount, opts)
 }
 
 
 // Approve a nETH spender
-func ApproveNETH(rp *rocketpool.RocketPool, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func ApproveNETH(rp *rocketpool.RocketPool, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenNETH, err := getRocketTokenNETH(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return approve(rocketTokenNETH, "nETH", spender, amount, opts)
 }
 
 
 // Transfer nETH from a sender
-func TransferFromNETH(rp *rocketpool.RocketPool, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func TransferFromNETH(rp *rocketpool.RocketPool, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenNETH, err := getRocketTokenNETH(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return transferFrom(rocketTokenNETH, "nETH", from, to, amount, opts)
 }
@@ -94,16 +91,16 @@ func GetNETHContractETHBalance(rp *rocketpool.RocketPool, opts *bind.CallOpts) (
 
 
 // Burn nETH for ETH
-func BurnNETH(rp *rocketpool.RocketPool, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BurnNETH(rp *rocketpool.RocketPool, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenNETH, err := getRocketTokenNETH(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketTokenNETH.Transact(opts, "burn", amount)
+    hash, err := rocketTokenNETH.Transact(opts, "burn", amount)
     if err != nil {
-        return nil, fmt.Errorf("Could not burn nETH: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not burn nETH: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/tokens/reth.go
+++ b/tokens/reth.go
@@ -1,23 +1,20 @@
 package tokens
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
-    "github.com/rocket-pool/rocketpool-go/utils/eth"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/utils/eth"
 )
-
 
 //
 // Core ERC-20 functions
 //
-
 
 // Get rETH total supply
 func GetRETHTotalSupply(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int, error) {
@@ -50,30 +47,30 @@ func GetRETHAllowance(rp *rocketpool.RocketPool, owner, spender common.Address, 
 
 
 // Transfer rETH
-func TransferRETH(rp *rocketpool.RocketPool, to common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func TransferRETH(rp *rocketpool.RocketPool, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenRETH, err := getRocketTokenRETH(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return transfer(rocketTokenRETH, "rETH", to, amount, opts)
 }
 
 
 // Approve a rETH spender
-func ApproveRETH(rp *rocketpool.RocketPool, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func ApproveRETH(rp *rocketpool.RocketPool, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenRETH, err := getRocketTokenRETH(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return approve(rocketTokenRETH, "rETH", spender, amount, opts)
 }
 
 
 // Transfer rETH from a sender
-func TransferFromRETH(rp *rocketpool.RocketPool, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func TransferFromRETH(rp *rocketpool.RocketPool, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenRETH, err := getRocketTokenRETH(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return transferFrom(rocketTokenRETH, "rETH", from, to, amount, opts)
 }
@@ -165,16 +162,16 @@ func GetRETHCollateralRate(rp *rocketpool.RocketPool, opts *bind.CallOpts) (floa
 
 
 // Burn rETH for ETH
-func BurnRETH(rp *rocketpool.RocketPool, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func BurnRETH(rp *rocketpool.RocketPool, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenRETH, err := getRocketTokenRETH(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketTokenRETH.Transact(opts, "burn", amount)
+    hash, err := rocketTokenRETH.Transact(opts, "burn", amount)
     if err != nil {
-        return nil, fmt.Errorf("Could not burn rETH: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not burn rETH: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/tokens/rpl-fixed.go
+++ b/tokens/rpl-fixed.go
@@ -1,21 +1,18 @@
 package tokens
 
 import (
-    "math/big"
-    "sync"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 //
 // Core ERC-20 functions
 //
-
 
 // Get fixed-supply RPL total supply
 func GetFixedSupplyRPLTotalSupply(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int, error) {
@@ -48,30 +45,30 @@ func GetFixedSupplyRPLAllowance(rp *rocketpool.RocketPool, owner, spender common
 
 
 // Transfer fixed-supply RPL
-func TransferFixedSupplyRPL(rp *rocketpool.RocketPool, to common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func TransferFixedSupplyRPL(rp *rocketpool.RocketPool, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenFixedSupplyRPL, err := getRocketTokenRPLFixedSupply(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return transfer(rocketTokenFixedSupplyRPL, "fixed-supply RPL", to, amount, opts)
 }
 
 
 // Approve an fixed-supply RPL spender
-func ApproveFixedSupplyRPL(rp *rocketpool.RocketPool, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func ApproveFixedSupplyRPL(rp *rocketpool.RocketPool, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenFixedSupplyRPL, err := getRocketTokenRPLFixedSupply(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return approve(rocketTokenFixedSupplyRPL, "fixed-supply RPL", spender, amount, opts)
 }
 
 
 // Transfer fixed-supply RPL from a sender
-func TransferFromFixedSupplyRPL(rp *rocketpool.RocketPool, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func TransferFromFixedSupplyRPL(rp *rocketpool.RocketPool, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenFixedSupplyRPL, err := getRocketTokenRPLFixedSupply(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return transferFrom(rocketTokenFixedSupplyRPL, "fixed-supply RPL", from, to, amount, opts)
 }

--- a/tokens/rpl.go
+++ b/tokens/rpl.go
@@ -1,22 +1,19 @@
 package tokens
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
+	"fmt"
+	"math/big"
+	"sync"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 //
 // Core ERC-20 functions
 //
-
 
 // Get RPL total supply
 func GetRPLTotalSupply(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*big.Int, error) {
@@ -49,30 +46,30 @@ func GetRPLAllowance(rp *rocketpool.RocketPool, owner, spender common.Address, o
 
 
 // Transfer RPL
-func TransferRPL(rp *rocketpool.RocketPool, to common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func TransferRPL(rp *rocketpool.RocketPool, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenRPL, err := getRocketTokenRPL(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return transfer(rocketTokenRPL, "RPL", to, amount, opts)
 }
 
 
 // Approve an RPL spender
-func ApproveRPL(rp *rocketpool.RocketPool, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func ApproveRPL(rp *rocketpool.RocketPool, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenRPL, err := getRocketTokenRPL(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return approve(rocketTokenRPL, "RPL", spender, amount, opts)
 }
 
 
 // Transfer RPL from a sender
-func TransferFromRPL(rp *rocketpool.RocketPool, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func TransferFromRPL(rp *rocketpool.RocketPool, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenRPL, err := getRocketTokenRPL(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
     return transferFrom(rocketTokenRPL, "RPL", from, to, amount, opts)
 }
@@ -84,30 +81,30 @@ func TransferFromRPL(rp *rocketpool.RocketPool, from, to common.Address, amount 
 
 
 // Mint new RPL tokens from inflation
-func MintInflationRPL(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (*types.Receipt, error) {
+func MintInflationRPL(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenRPL, err := getRocketTokenRPL(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketTokenRPL.Transact(opts, "inflationMintTokens")
+    hash, err := rocketTokenRPL.Transact(opts, "inflationMintTokens")
     if err != nil {
-        return nil, fmt.Errorf("Could not mint RPL tokens from inflation: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not mint RPL tokens from inflation: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Swap fixed-supply RPL for new RPL tokens
-func SwapFixedSupplyRPLForRPL(rp *rocketpool.RocketPool, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
+func SwapFixedSupplyRPLForRPL(rp *rocketpool.RocketPool, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
     rocketTokenRPL, err := getRocketTokenRPL(rp)
     if err != nil {
-        return nil, err
+        return common.Hash{}, err
     }
-    txReceipt, err := rocketTokenRPL.Transact(opts, "swapTokens", amount)
+    hash, err := rocketTokenRPL.Transact(opts, "swapTokens", amount)
     if err != nil {
-        return nil, fmt.Errorf("Could not swap fixed-supply RPL for new RPL: %w", err)
+        return common.Hash{}, fmt.Errorf("Could not swap fixed-supply RPL for new RPL: %w", err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -1,18 +1,16 @@
 package tokens
 
 import (
-    "context"
-    "fmt"
-    "math/big"
+	"context"
+	"fmt"
+	"math/big"
 
-    "github.com/ethereum/go-ethereum/accounts/abi/bind"
-    "github.com/ethereum/go-ethereum/common"
-    "github.com/ethereum/go-ethereum/core/types"
-    "golang.org/x/sync/errgroup"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/sync/errgroup"
 
-    "github.com/rocket-pool/rocketpool-go/rocketpool"
+	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
-
 
 // Token balances
 type Balances struct {
@@ -122,31 +120,31 @@ func allowance(tokenContract *rocketpool.Contract, tokenName string, owner, spen
 
 
 // Transfer tokens to an address
-func transfer(tokenContract *rocketpool.Contract, tokenName string, to common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
-    txReceipt, err := tokenContract.Transact(opts, "transfer", to, amount)
+func transfer(tokenContract *rocketpool.Contract, tokenName string, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
+    hash, err := tokenContract.Transact(opts, "transfer", to, amount)
     if err != nil {
-        return nil, fmt.Errorf("Could not transfer %s to %s: %w", tokenName, to.Hex(), err)
+        return common.Hash{}, fmt.Errorf("Could not transfer %s to %s: %w", tokenName, to.Hex(), err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Approve a token allowance for a spender
-func approve(tokenContract *rocketpool.Contract, tokenName string, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
-    txReceipt, err := tokenContract.Transact(opts, "approve", spender, amount)
+func approve(tokenContract *rocketpool.Contract, tokenName string, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
+    hash, err := tokenContract.Transact(opts, "approve", spender, amount)
     if err != nil {
-        return nil, fmt.Errorf("Could not approve %s allowance for %s: %w", tokenName, spender.Hex(), err)
+        return common.Hash{}, fmt.Errorf("Could not approve %s allowance for %s: %w", tokenName, spender.Hex(), err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 
 
 // Transfer tokens from a sender to an address
-func transferFrom(tokenContract *rocketpool.Contract, tokenName string, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (*types.Receipt, error) {
-    txReceipt, err := tokenContract.Transact(opts, "transferFrom", from, to, amount)
+func transferFrom(tokenContract *rocketpool.Contract, tokenName string, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
+    hash, err := tokenContract.Transact(opts, "transferFrom", from, to, amount)
     if err != nil {
-        return nil, fmt.Errorf("Could not transfer %s from %s to %s: %w", tokenName, from.Hex(), to.Hex(), err)
+        return common.Hash{}, fmt.Errorf("Could not transfer %s from %s to %s: %w", tokenName, from.Hex(), to.Hex(), err)
     }
-    return txReceipt, nil
+    return hash, nil
 }
 

--- a/utils/eth/transactions.go
+++ b/utils/eth/transactions.go
@@ -2,7 +2,6 @@ package eth
 
 import (
 	"context"
-	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -71,31 +70,6 @@ func SendTransaction(client *ethclient.Client, toAddress common.Address, opts *b
     }
 
     return signedTx.Hash(), nil
-
-}
-
-
-func WaitForSendTransaction(client *ethclient.Client, hash common.Hash) (*types.Receipt, error) {
-
-    // Get the tx by its hash
-    tx, _, err := client.TransactionByHash(context.Background(), hash)
-    if err != nil {
-        return nil, err
-    }
-
-    // Wait for transaction to be mined
-    txReceipt, err := bind.WaitMined(context.Background(), client, tx)
-    if err != nil {
-        return nil, err
-    }
-
-    // Check transaction status
-    if txReceipt.Status == 0 {
-        return txReceipt, errors.New("Transaction failed with status 0")
-    }
-
-    // Return
-    return txReceipt, nil
 
 }
 

--- a/utils/wait.go
+++ b/utils/wait.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// Wait for a transaction to get mined
+func WaitForTransaction(client *ethclient.Client, hash common.Hash) (*types.Receipt, error) {
+    
+    // Get the transaction from its hash
+    tx, _, err := client.TransactionByHash(context.Background(), hash)
+    if err != nil {
+        return nil, err
+    }
+
+    // Wait for transaction to be mined
+    txReceipt, err := bind.WaitMined(context.Background(), client, tx)
+    if err != nil {
+        return nil, err
+    }
+
+    // Check transaction status
+    if txReceipt.Status == 0 {
+        return txReceipt, errors.New("Transaction failed with status 0")
+    }
+
+    // Return
+    return txReceipt, nil
+}
+


### PR DESCRIPTION
This adds asynchronous support to each commands that involves submitting transactions to eth1. It returns the TX hash immediately, and offers a separate function to block until that TX has been mined (replicating the old behavior if desired).

**NOTE: This affects a *ton* of commands, and it needs to be tested extremely thoroughly before deployment!**