### PR TITLE
Wrap json unmarshal errors for more verbose output

### DIFF
--- a/types/beacon.go
+++ b/types/beacon.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 
 	"encoding/hex"
-	"encoding/json"
+
+	"github.com/rocket-pool/rocketpool-go/utils/json"
 )
 
 // Validator pubkey

--- a/types/dao.go
+++ b/types/dao.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"encoding/json"
 	"fmt"
+
+	"github.com/rocket-pool/rocketpool-go/utils/json"
 )
 
 // DAO proposal states

--- a/types/minipool.go
+++ b/types/minipool.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"encoding/json"
 	"fmt"
+
+	"github.com/rocket-pool/rocketpool-go/utils/json"
 )
 
 // Minipool statuses

--- a/utils/json/json.go
+++ b/utils/json/json.go
@@ -1,0 +1,19 @@
+package json 
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func Marshal(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func Unmarshal(data []byte, v interface{}) error {
+	err := json.Unmarshal(data, v)
+	if err != nil {
+		return fmt.Errorf("%w\nUnable to Unmarshal JSON string %s", string(data))
+	}
+
+	return nil
+}

--- a/utils/json/json.go
+++ b/utils/json/json.go
@@ -12,7 +12,7 @@ func Marshal(v interface{}) ([]byte, error) {
 func Unmarshal(data []byte, v interface{}) error {
 	err := json.Unmarshal(data, v)
 	if err != nil {
-		return fmt.Errorf("%w\nUnable to Unmarshal JSON string %s", string(data))
+		return fmt.Errorf("%w\nUnable to Unmarshal JSON string %s", err, string(data))
 	}
 
 	return nil


### PR DESCRIPTION
While supporting smartnode users, we frequently see errors like:
![image](https://user-images.githubusercontent.com/116244/160257623-b547733a-5d8a-4569-ab2c-3be0dc3b5bb1.png)

This PR introduces a minimal facade around encoding/json that adds the raw buffer to the error message, to facilitate debugging.