### PR TITLE
Return the whole transaction from Transact

### DIFF
--- a/auction/auction.go
+++ b/auction/auction.go
@@ -523,11 +523,11 @@ func CreateLot(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (uint64, comm
 	if err != nil {
 		return 0, common.Hash{}, err
 	}
-	hash, err := rocketAuctionManager.Transact(opts, "createLot")
+	tx, err := rocketAuctionManager.Transact(opts, "createLot")
 	if err != nil {
 		return 0, common.Hash{}, fmt.Errorf("Could not create lot: %w", err)
 	}
-	return lotCount, hash, nil
+	return lotCount, tx.Hash(), nil
 }
 
 // Estimate the gas of PlaceBid
@@ -545,11 +545,11 @@ func PlaceBid(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.TransactOpt
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketAuctionManager.Transact(opts, "placeBid", big.NewInt(int64(lotIndex)))
+	tx, err := rocketAuctionManager.Transact(opts, "placeBid", big.NewInt(int64(lotIndex)))
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not place bid on lot %d: %w", lotIndex, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of ClaimBid
@@ -567,11 +567,11 @@ func ClaimBid(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.TransactOpt
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketAuctionManager.Transact(opts, "claimBid", big.NewInt(int64(lotIndex)))
+	tx, err := rocketAuctionManager.Transact(opts, "claimBid", big.NewInt(int64(lotIndex)))
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not claim bid from lot %d: %w", lotIndex, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of RecoverUnclaimedRPL
@@ -589,11 +589,11 @@ func RecoverUnclaimedRPL(rp *rocketpool.RocketPool, lotIndex uint64, opts *bind.
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketAuctionManager.Transact(opts, "recoverUnclaimedRPL", big.NewInt(int64(lotIndex)))
+	tx, err := rocketAuctionManager.Transact(opts, "recoverUnclaimedRPL", big.NewInt(int64(lotIndex)))
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not recover unclaimed RPL from lot %d: %w", lotIndex, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get contracts

--- a/dao/protocol/dao.go
+++ b/dao/protocol/dao.go
@@ -27,11 +27,11 @@ func BootstrapBool(rp *rocketpool.RocketPool, contractName, settingPath string, 
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingBool", contractName, settingPath, value)
+	tx, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingBool", contractName, settingPath, value)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not bootstrap protocol setting %s.%s: %w", contractName, settingPath, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of BootstrapUint
@@ -49,11 +49,11 @@ func BootstrapUint(rp *rocketpool.RocketPool, contractName, settingPath string, 
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingUint", contractName, settingPath, value)
+	tx, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingUint", contractName, settingPath, value)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not bootstrap protocol setting %s.%s: %w", contractName, settingPath, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of BootstrapAddress
@@ -71,11 +71,11 @@ func BootstrapAddress(rp *rocketpool.RocketPool, contractName, settingPath strin
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingAddress", contractName, settingPath, value)
+	tx, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingAddress", contractName, settingPath, value)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not bootstrap protocol setting %s.%s: %w", contractName, settingPath, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of BootstrapClaimer
@@ -93,11 +93,11 @@ func BootstrapClaimer(rp *rocketpool.RocketPool, contractName string, amount flo
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingClaimer", contractName, eth.EthToWei(amount))
+	tx, err := rocketDAOProtocol.Transact(opts, "bootstrapSettingClaimer", contractName, eth.EthToWei(amount))
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not bootstrap protocol rewards claimer %s: %w", contractName, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get contracts

--- a/dao/trustednode/actions.go
+++ b/dao/trustednode/actions.go
@@ -26,11 +26,11 @@ func Join(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.Hash, erro
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrustedActions.Transact(opts, "actionJoin")
+	tx, err := rocketDAONodeTrustedActions.Transact(opts, "actionJoin")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not join the trusted node DAO: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of Leave
@@ -49,11 +49,11 @@ func Leave(rp *rocketpool.RocketPool, rplBondRefundAddress common.Address, opts 
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrustedActions.Transact(opts, "actionLeave", rplBondRefundAddress)
+	tx, err := rocketDAONodeTrustedActions.Transact(opts, "actionLeave", rplBondRefundAddress)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not leave the trusted node DAO: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of MakeChallenge
@@ -71,11 +71,11 @@ func MakeChallenge(rp *rocketpool.RocketPool, memberAddress common.Address, opts
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrustedActions.Transact(opts, "actionChallengeMake", memberAddress)
+	tx, err := rocketDAONodeTrustedActions.Transact(opts, "actionChallengeMake", memberAddress)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not challenge trusted node DAO member %s: %w", memberAddress.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of DecideChallenge
@@ -93,11 +93,11 @@ func DecideChallenge(rp *rocketpool.RocketPool, memberAddress common.Address, op
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrustedActions.Transact(opts, "actionChallengeDecide", memberAddress)
+	tx, err := rocketDAONodeTrustedActions.Transact(opts, "actionChallengeDecide", memberAddress)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not decide the challenge against trusted node DAO member %s: %w", memberAddress.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get contracts

--- a/dao/trustednode/dao.go
+++ b/dao/trustednode/dao.go
@@ -368,11 +368,11 @@ func BootstrapBool(rp *rocketpool.RocketPool, contractName, settingPath string, 
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrusted.Transact(opts, "bootstrapSettingBool", contractName, settingPath, value)
+	tx, err := rocketDAONodeTrusted.Transact(opts, "bootstrapSettingBool", contractName, settingPath, value)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not bootstrap trusted node setting %s.%s: %w", contractName, settingPath, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of BootstrapUint
@@ -390,11 +390,11 @@ func BootstrapUint(rp *rocketpool.RocketPool, contractName, settingPath string, 
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrusted.Transact(opts, "bootstrapSettingUint", contractName, settingPath, value)
+	tx, err := rocketDAONodeTrusted.Transact(opts, "bootstrapSettingUint", contractName, settingPath, value)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not bootstrap trusted node setting %s.%s: %w", contractName, settingPath, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of BootstrapMember
@@ -414,11 +414,11 @@ func BootstrapMember(rp *rocketpool.RocketPool, id, url string, nodeAddress comm
 		return common.Hash{}, err
 	}
 	url = strings.Sanitize(url)
-	hash, err := rocketDAONodeTrusted.Transact(opts, "bootstrapMember", id, url, nodeAddress)
+	tx, err := rocketDAONodeTrusted.Transact(opts, "bootstrapMember", id, url, nodeAddress)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not bootstrap trusted node member %s: %w", id, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of BootstrapUpgrade
@@ -444,11 +444,11 @@ func BootstrapUpgrade(rp *rocketpool.RocketPool, upgradeType, contractName, cont
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrusted.Transact(opts, "bootstrapUpgrade", upgradeType, contractName, compressedAbi, contractAddress)
+	tx, err := rocketDAONodeTrusted.Transact(opts, "bootstrapUpgrade", upgradeType, contractName, compressedAbi, contractAddress)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not bootstrap contract '%s' upgrade (%s): %w", contractName, upgradeType, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get contracts

--- a/dao/trustednode/proposals.go
+++ b/dao/trustednode/proposals.go
@@ -227,11 +227,11 @@ func SubmitProposal(rp *rocketpool.RocketPool, message string, payload []byte, o
 	if err != nil {
 		return 0, common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrustedProposals.Transact(opts, "propose", message, payload)
+	tx, err := rocketDAONodeTrustedProposals.Transact(opts, "propose", message, payload)
 	if err != nil {
 		return 0, common.Hash{}, fmt.Errorf("Could not submit trusted node DAO proposal: %w", err)
 	}
-	return proposalCount + 1, hash, nil
+	return proposalCount + 1, tx.Hash(), nil
 }
 
 // Estimate the gas of CancelProposal
@@ -249,11 +249,11 @@ func CancelProposal(rp *rocketpool.RocketPool, proposalId uint64, opts *bind.Tra
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrustedProposals.Transact(opts, "cancel", big.NewInt(int64(proposalId)))
+	tx, err := rocketDAONodeTrustedProposals.Transact(opts, "cancel", big.NewInt(int64(proposalId)))
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not cancel trusted node DAO proposal %d: %w", proposalId, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of VoteOnProposal
@@ -271,11 +271,11 @@ func VoteOnProposal(rp *rocketpool.RocketPool, proposalId uint64, support bool, 
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrustedProposals.Transact(opts, "vote", big.NewInt(int64(proposalId)), support)
+	tx, err := rocketDAONodeTrustedProposals.Transact(opts, "vote", big.NewInt(int64(proposalId)), support)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not vote on trusted node DAO proposal %d: %w", proposalId, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of ExecuteProposal
@@ -293,11 +293,11 @@ func ExecuteProposal(rp *rocketpool.RocketPool, proposalId uint64, opts *bind.Tr
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDAONodeTrustedProposals.Transact(opts, "execute", big.NewInt(int64(proposalId)))
+	tx, err := rocketDAONodeTrustedProposals.Transact(opts, "execute", big.NewInt(int64(proposalId)))
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not execute trusted node DAO proposal %d: %w", proposalId, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get contracts

--- a/deposit/deposit.go
+++ b/deposit/deposit.go
@@ -52,11 +52,11 @@ func Deposit(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.Hash, e
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDepositPool.Transact(opts, "deposit")
+	tx, err := rocketDepositPool.Transact(opts, "deposit")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not deposit: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of AssignDeposits
@@ -74,11 +74,11 @@ func AssignDeposits(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (common.
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDepositPool.Transact(opts, "assignDeposits")
+	tx, err := rocketDepositPool.Transact(opts, "assignDeposits")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not assign deposits: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get contracts

--- a/legacy/v1.0.0/rewards/rewards.go
+++ b/legacy/v1.0.0/rewards/rewards.go
@@ -84,11 +84,11 @@ func estimateClaimGas(claimsContract *rocketpool.Contract, opts *bind.TransactOp
 
 // Claim rewards
 func claim(claimsContract *rocketpool.Contract, claimsName string, opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := claimsContract.Transact(opts, "claim")
+	tx, err := claimsContract.Transact(opts, "claim")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not claim %s rewards: %w", claimsName, err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get the timestamp that the current rewards interval started

--- a/legacy/v1.5.0-rc1/rewards/rewards.go
+++ b/legacy/v1.5.0-rc1/rewards/rewards.go
@@ -164,11 +164,11 @@ func SubmitRewardSnapshot(rp *rocketpool.RocketPool, submission RewardSubmission
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketRewardsPool.Transact(opts, "submitRewardSnapshot", submission)
+	tx, err := rocketRewardsPool.Transact(opts, "submitRewardSnapshot", submission)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not submit rewards snapshot: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get the event info for a rewards snapshot

--- a/minipool/minipool-contract.go
+++ b/minipool/minipool-contract.go
@@ -326,11 +326,11 @@ func (mp *Minipool) EstimateRefundGas(opts *bind.TransactOpts) (rocketpool.GasIn
 
 // Refund node ETH from the minipool
 func (mp *Minipool) Refund(opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "refund")
+	tx, err := mp.Contract.Transact(opts, "refund")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not refund from minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of DistributeBalance
@@ -343,11 +343,11 @@ func (mp *Minipool) EstimateDistributeBalanceGas(opts *bind.TransactOpts) (rocke
 // DO NOT CALL THIS until the minipool's validator has exited from the Beacon Chain
 // and the balance has been deposited into the minipool!
 func (mp *Minipool) DistributeBalance(opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "distributeBalance")
+	tx, err := mp.Contract.Transact(opts, "distributeBalance")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not process withdrawal for minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of DistributeBalanceAndFinalise
@@ -361,11 +361,11 @@ func (mp *Minipool) EstimateDistributeBalanceAndFinaliseGas(opts *bind.TransactO
 // DO NOT CALL THIS until the minipool's validator has exited from the Beacon Chain
 // and the balance has been deposited into the minipool!
 func (mp *Minipool) DistributeBalanceAndFinalise(opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "distributeBalanceAndFinalise")
+	tx, err := mp.Contract.Transact(opts, "distributeBalanceAndFinalise")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not process withdrawal for and finalise minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of Stake
@@ -375,11 +375,11 @@ func (mp *Minipool) EstimateStakeGas(validatorSignature rptypes.ValidatorSignatu
 
 // Progress the prelaunch minipool to staking
 func (mp *Minipool) Stake(validatorSignature rptypes.ValidatorSignature, depositDataRoot common.Hash, opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "stake", validatorSignature[:], depositDataRoot)
+	tx, err := mp.Contract.Transact(opts, "stake", validatorSignature[:], depositDataRoot)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not stake minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of Dissolve
@@ -389,11 +389,11 @@ func (mp *Minipool) EstimateDissolveGas(opts *bind.TransactOpts) (rocketpool.Gas
 
 // Dissolve the initialized or prelaunch minipool
 func (mp *Minipool) Dissolve(opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "dissolve")
+	tx, err := mp.Contract.Transact(opts, "dissolve")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not dissolve minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of Close
@@ -403,11 +403,11 @@ func (mp *Minipool) EstimateCloseGas(opts *bind.TransactOpts) (rocketpool.GasInf
 
 // Withdraw node balances from the dissolved minipool and close it
 func (mp *Minipool) Close(opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "close")
+	tx, err := mp.Contract.Transact(opts, "close")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not close minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of Finalise
@@ -417,11 +417,11 @@ func (mp *Minipool) EstimateFinaliseGas(opts *bind.TransactOpts) (rocketpool.Gas
 
 // Finalise a minipool to get the RPL stake back
 func (mp *Minipool) Finalise(opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "finalise")
+	tx, err := mp.Contract.Transact(opts, "finalise")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not finalise minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of DelegateUpgrade
@@ -431,11 +431,11 @@ func (mp *Minipool) EstimateDelegateUpgradeGas(opts *bind.TransactOpts) (rocketp
 
 // Upgrade this minipool to the latest network delegate contract
 func (mp *Minipool) DelegateUpgrade(opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "delegateUpgrade")
+	tx, err := mp.Contract.Transact(opts, "delegateUpgrade")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not upgrade delegate for minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of DelegateRollback
@@ -445,11 +445,11 @@ func (mp *Minipool) EstimateDelegateRollbackGas(opts *bind.TransactOpts) (rocket
 
 // Rollback to previous delegate contract
 func (mp *Minipool) DelegateRollback(opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "delegateRollback")
+	tx, err := mp.Contract.Transact(opts, "delegateRollback")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not rollback delegate for minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of SetUseLatestDelegate
@@ -459,11 +459,11 @@ func (mp *Minipool) EstimateSetUseLatestDelegateGas(setting bool, opts *bind.Tra
 
 // If set to true, will automatically use the latest delegate contract
 func (mp *Minipool) SetUseLatestDelegate(setting bool, opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "setUseLatestDelegate", setting)
+	tx, err := mp.Contract.Transact(opts, "setUseLatestDelegate", setting)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not set use latest delegate for minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Getter for useLatestDelegate setting
@@ -527,11 +527,11 @@ func (mp *Minipool) EstimateVoteScrubGas(opts *bind.TransactOpts) (rocketpool.Ga
 
 // Vote to scrub a minipool
 func (mp *Minipool) VoteScrub(opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := mp.Contract.Transact(opts, "voteScrub")
+	tx, err := mp.Contract.Transact(opts, "voteScrub")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not vote to scrub minipool %s: %w", mp.Address.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get the data from this minipool's MinipoolPrestaked event

--- a/minipool/status.go
+++ b/minipool/status.go
@@ -25,11 +25,11 @@ func SubmitMinipoolWithdrawable(rp *rocketpool.RocketPool, minipoolAddress commo
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketMinipoolStatus.Transact(opts, "submitMinipoolWithdrawable", minipoolAddress)
+	tx, err := rocketMinipoolStatus.Transact(opts, "submitMinipoolWithdrawable", minipoolAddress)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not submit minipool withdrawable event: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get contracts

--- a/network/balances.go
+++ b/network/balances.go
@@ -92,11 +92,11 @@ func SubmitBalances(rp *rocketpool.RocketPool, block uint64, totalEth, stakingEt
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketNetworkBalances.Transact(opts, "submitBalances", big.NewInt(int64(block)), totalEth, stakingEth, rethSupply)
+	tx, err := rocketNetworkBalances.Transact(opts, "submitBalances", big.NewInt(int64(block)), totalEth, stakingEth, rethSupply)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not submit network balances: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Returns the latest block number that oracles should be reporting balances for

--- a/network/penalties.go
+++ b/network/penalties.go
@@ -26,11 +26,11 @@ func SubmitPenalty(rp *rocketpool.RocketPool, minipoolAddress common.Address, bl
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketNetworkPrices.Transact(opts, "submitPenalty", minipoolAddress, block)
+	tx, err := rocketNetworkPrices.Transact(opts, "submitPenalty", minipoolAddress, block)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not submit penalty: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get contracts

--- a/network/prices.go
+++ b/network/prices.go
@@ -52,11 +52,11 @@ func SubmitPrices(rp *rocketpool.RocketPool, block uint64, rplPrice, effectiveRp
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketNetworkPrices.Transact(opts, "submitPrices", big.NewInt(int64(block)), rplPrice, effectiveRplStake)
+	tx, err := rocketNetworkPrices.Transact(opts, "submitPrices", big.NewInt(int64(block)), rplPrice, effectiveRplStake)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not submit network prices: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Check if the network is currently in consensus about the RPL price, or if it is still reaching consensus

--- a/node/deposit.go
+++ b/node/deposit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
 	rptypes "github.com/rocket-pool/rocketpool-go/types"
@@ -23,16 +24,16 @@ func EstimateDepositGas(rp *rocketpool.RocketPool, minimumNodeFee float64, valid
 }
 
 // Make a node deposit
-func Deposit(rp *rocketpool.RocketPool, minimumNodeFee float64, validatorPubkey rptypes.ValidatorPubkey, validatorSignature rptypes.ValidatorSignature, depositDataRoot common.Hash, salt *big.Int, expectedMinipoolAddress common.Address, opts *bind.TransactOpts) (common.Hash, error) {
+func Deposit(rp *rocketpool.RocketPool, minimumNodeFee float64, validatorPubkey rptypes.ValidatorPubkey, validatorSignature rptypes.ValidatorSignature, depositDataRoot common.Hash, salt *big.Int, expectedMinipoolAddress common.Address, opts *bind.TransactOpts) (*types.Transaction, error) {
 	rocketNodeDeposit, err := getRocketNodeDeposit(rp)
 	if err != nil {
-		return common.Hash{}, err
+		return nil, err
 	}
 	tx, err := rocketNodeDeposit.Transact(opts, "deposit", eth.EthToWei(minimumNodeFee), validatorPubkey[:], validatorSignature[:], depositDataRoot, salt, expectedMinipoolAddress)
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("Could not make node deposit: %w", err)
+		return nil, fmt.Errorf("Could not make node deposit: %w", err)
 	}
-	return tx.Hash(), nil
+	return tx, nil
 }
 
 // Get the type of a deposit based on the amount

--- a/node/deposit.go
+++ b/node/deposit.go
@@ -28,11 +28,11 @@ func Deposit(rp *rocketpool.RocketPool, minimumNodeFee float64, validatorPubkey 
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketNodeDeposit.Transact(opts, "deposit", eth.EthToWei(minimumNodeFee), validatorPubkey[:], validatorSignature[:], depositDataRoot, salt, expectedMinipoolAddress)
+	tx, err := rocketNodeDeposit.Transact(opts, "deposit", eth.EthToWei(minimumNodeFee), validatorPubkey[:], validatorSignature[:], depositDataRoot, salt, expectedMinipoolAddress)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not make node deposit: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get the type of a deposit based on the amount

--- a/node/distributor.go
+++ b/node/distributor.go
@@ -54,11 +54,11 @@ func (d *Distributor) EstimateDistributeGas(opts *bind.TransactOpts) (rocketpool
 
 // Distribute the contract's balance to the rETH contract and the user
 func (d *Distributor) Distribute(opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := d.Contract.Transact(opts, "distribute")
+	tx, err := d.Contract.Transact(opts, "distribute")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not distribute fee distributor balance: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get contracts

--- a/node/node.go
+++ b/node/node.go
@@ -320,11 +320,11 @@ func RegisterNode(rp *rocketpool.RocketPool, timezoneLocation string, opts *bind
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not verify timezone [%s]: %w", timezoneLocation, err)
 	}
-	hash, err := rocketNodeManager.Transact(opts, "registerNode", timezoneLocation)
+	tx, err := rocketNodeManager.Transact(opts, "registerNode", timezoneLocation)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not register node: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of SetTimezoneLocation
@@ -350,11 +350,11 @@ func SetTimezoneLocation(rp *rocketpool.RocketPool, timezoneLocation string, opt
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not verify timezone [%s]: %w", timezoneLocation, err)
 	}
-	hash, err := rocketNodeManager.Transact(opts, "setTimezoneLocation", timezoneLocation)
+	tx, err := rocketNodeManager.Transact(opts, "setTimezoneLocation", timezoneLocation)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not set node timezone location: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get the network ID for a node's rewards
@@ -398,11 +398,11 @@ func InitializeFeeDistributor(rp *rocketpool.RocketPool, opts *bind.TransactOpts
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketNodeManager.Transact(opts, "initialiseFeeDistributor")
+	tx, err := rocketNodeManager.Transact(opts, "initialiseFeeDistributor")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not initialize fee distributor: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get a node's average minipool fee
@@ -873,11 +873,11 @@ func SetSmoothingPoolRegistrationState(rp *rocketpool.RocketPool, optIn bool, op
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketNodeManager.Transact(opts, "setSmoothingPoolRegistrationState", optIn)
+	tx, err := rocketNodeManager.Transact(opts, "setSmoothingPoolRegistrationState", optIn)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not set smoothing pool registration state: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get the number of nodes in the Smoothing Pool

--- a/node/staking.go
+++ b/node/staking.go
@@ -142,11 +142,11 @@ func StakeRPL(rp *rocketpool.RocketPool, rplAmount *big.Int, opts *bind.Transact
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketNodeStaking.Transact(opts, "stakeRPL", rplAmount)
+	tx, err := rocketNodeStaking.Transact(opts, "stakeRPL", rplAmount)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not stake RPL: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of WithdrawRPL
@@ -164,11 +164,11 @@ func WithdrawRPL(rp *rocketpool.RocketPool, rplAmount *big.Int, opts *bind.Trans
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketNodeStaking.Transact(opts, "withdrawRPL", rplAmount)
+	tx, err := rocketNodeStaking.Transact(opts, "withdrawRPL", rplAmount)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not withdraw staked RPL: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Calculate total effective RPL stake

--- a/rewards/distributor-mainnet.go
+++ b/rewards/distributor-mainnet.go
@@ -51,11 +51,11 @@ func Claim(rp *rocketpool.RocketPool, address common.Address, indices []*big.Int
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDistributorMainnet.Transact(opts, "claim", address, indices, amountRPL, amountETH, merkleProofs)
+	tx, err := rocketDistributorMainnet.Transact(opts, "claim", address, indices, amountRPL, amountETH, merkleProofs)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not claim rewards: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate claim and restake rewards gas
@@ -73,11 +73,11 @@ func ClaimAndStake(rp *rocketpool.RocketPool, address common.Address, indices []
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketDistributorMainnet.Transact(opts, "claimAndStake", address, indices, amountRPL, amountETH, merkleProofs, stakeAmount)
+	tx, err := rocketDistributorMainnet.Transact(opts, "claimAndStake", address, indices, amountRPL, amountETH, merkleProofs, stakeAmount)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not claim rewards: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get contracts

--- a/rewards/rewards.go
+++ b/rewards/rewards.go
@@ -166,11 +166,11 @@ func SubmitRewardSnapshot(rp *rocketpool.RocketPool, submission RewardSubmission
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketRewardsPool.Transact(opts, "submitRewardSnapshot", submission)
+	tx, err := rocketRewardsPool.Transact(opts, "submitRewardSnapshot", submission)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not submit rewards snapshot: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get the event info for a rewards snapshot

--- a/rocketpool/contract.go
+++ b/rocketpool/contract.go
@@ -66,17 +66,17 @@ func (c *Contract) GetTransactionGasInfo(opts *bind.TransactOpts, method string,
 }
 
 // Transact on a contract method and wait for a receipt
-func (c *Contract) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (common.Hash, error) {
+func (c *Contract) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
 
 	// Estimate gas limit
 	if opts.GasLimit == 0 {
 		input, err := c.ABI.Pack(method, params...)
 		if err != nil {
-			return common.Hash{}, fmt.Errorf("Could not encode input data: %w", err)
+			return nil, fmt.Errorf("Could not encode input data: %w", err)
 		}
 		_, safeGasLimit, err := c.estimateGasLimit(opts, input)
 		if err != nil {
-			return common.Hash{}, err
+			return nil, err
 		}
 		opts.GasLimit = safeGasLimit
 	}
@@ -84,10 +84,10 @@ func (c *Contract) Transact(opts *bind.TransactOpts, method string, params ...in
 	// Send transaction
 	tx, err := c.Contract.Transact(opts, method, params...)
 	if err != nil {
-		return common.Hash{}, err
+		return nil, err
 	}
 
-	return tx.Hash(), nil
+	return tx, nil
 
 }
 

--- a/storage/rocket-storage.go
+++ b/storage/rocket-storage.go
@@ -33,11 +33,11 @@ func EstimateSetWithdrawalAddressGas(rp *rocketpool.RocketPool, nodeAddress comm
 
 // Set a node's withdrawal address
 func SetWithdrawalAddress(rp *rocketpool.RocketPool, nodeAddress common.Address, withdrawalAddress common.Address, confirm bool, opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := rp.RocketStorageContract.Transact(opts, "setWithdrawalAddress", nodeAddress, withdrawalAddress, confirm)
+	tx, err := rp.RocketStorageContract.Transact(opts, "setWithdrawalAddress", nodeAddress, withdrawalAddress, confirm)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not set node withdrawal address: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of ConfirmWithdrawalAddress
@@ -47,9 +47,9 @@ func EstimateConfirmWithdrawalAddressGas(rp *rocketpool.RocketPool, nodeAddress 
 
 // Set a node's withdrawal address
 func ConfirmWithdrawalAddress(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := rp.RocketStorageContract.Transact(opts, "confirmWithdrawalAddress", nodeAddress)
+	tx, err := rp.RocketStorageContract.Transact(opts, "confirmWithdrawalAddress", nodeAddress)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not confirm node withdrawal address: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }

--- a/tokens/reth.go
+++ b/tokens/reth.go
@@ -190,11 +190,11 @@ func BurnRETH(rp *rocketpool.RocketPool, amount *big.Int, opts *bind.TransactOpt
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketTokenRETH.Transact(opts, "burn", amount)
+	tx, err := rocketTokenRETH.Transact(opts, "burn", amount)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not burn rETH: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 //

--- a/tokens/rpl.go
+++ b/tokens/rpl.go
@@ -115,11 +115,11 @@ func MintInflationRPL(rp *rocketpool.RocketPool, opts *bind.TransactOpts) (commo
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketTokenRPL.Transact(opts, "inflationMintTokens")
+	tx, err := rocketTokenRPL.Transact(opts, "inflationMintTokens")
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not mint RPL tokens from inflation: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of SwapFixedSupplyRPLForRPL
@@ -137,11 +137,11 @@ func SwapFixedSupplyRPLForRPL(rp *rocketpool.RocketPool, amount *big.Int, opts *
 	if err != nil {
 		return common.Hash{}, err
 	}
-	hash, err := rocketTokenRPL.Transact(opts, "swapTokens", amount)
+	tx, err := rocketTokenRPL.Transact(opts, "swapTokens", amount)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not swap fixed-supply RPL for new RPL: %w", err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Get the RPL inflation interval rate

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -116,11 +116,11 @@ func estimateTransferGas(tokenContract *rocketpool.Contract, tokenName string, t
 
 // Transfer tokens to an address
 func transfer(tokenContract *rocketpool.Contract, tokenName string, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := tokenContract.Transact(opts, "transfer", to, amount)
+	tx, err := tokenContract.Transact(opts, "transfer", to, amount)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not transfer %s to %s: %w", tokenName, to.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of approve
@@ -130,11 +130,11 @@ func estimateApproveGas(tokenContract *rocketpool.Contract, tokenName string, sp
 
 // Approve a token allowance for a spender
 func approve(tokenContract *rocketpool.Contract, tokenName string, spender common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := tokenContract.Transact(opts, "approve", spender, amount)
+	tx, err := tokenContract.Transact(opts, "approve", spender, amount)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not approve %s allowance for %s: %w", tokenName, spender.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }
 
 // Estimate the gas of transferFrom
@@ -144,9 +144,9 @@ func estimateTransferFromGas(tokenContract *rocketpool.Contract, tokenName strin
 
 // Transfer tokens from a sender to an address
 func transferFrom(tokenContract *rocketpool.Contract, tokenName string, from, to common.Address, amount *big.Int, opts *bind.TransactOpts) (common.Hash, error) {
-	hash, err := tokenContract.Transact(opts, "transferFrom", from, to, amount)
+	tx, err := tokenContract.Transact(opts, "transferFrom", from, to, amount)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("Could not transfer %s from %s to %s: %w", tokenName, from.Hex(), to.Hex(), err)
 	}
-	return hash, nil
+	return tx.Hash(), nil
 }


### PR DESCRIPTION
Instead of just returning the `tx.Hash()`, return the whole transaction. This is to allow the transaction data (e.g. from `tx.EncodeRLP`) to be output by higher-level commands, e.g., when instructed to not send the transaction.