### PR TITLE
Fix Deposit usage

### DIFF
--- a/tests/testutils/node/deposit.go
+++ b/tests/testutils/node/deposit.go
@@ -64,11 +64,11 @@ func Deposit(t *testing.T, rp *rocketpool.RocketPool, nodeAccount *accounts.Acco
 	minNodeFee := 0.0
 	//t.Logf("Deposit:\n\tMin Node Fee: %f\n\tValidator Pubkey: %s\n\tValidator Signature: %s\n\tDeposit Data Root: %s\n\tNode Address: %s\n\tSalt: %s\n\tExpected Minipool: %s\n",
 	//    minNodeFee, validatorPubkey.Hex(), validatorSignature.Hex(), depositDataRoot.Hex(), nodeAccount.Address.Hex(), GetDefaultSalt().String(), expectedMinipoolAddress.Hex())
-	hash, err := node.Deposit(rp, minNodeFee, validatorPubkey, validatorSignature, depositDataRoot, salt, expectedMinipoolAddress, opts)
+	tx, err := node.Deposit(rp, minNodeFee, validatorPubkey, validatorSignature, depositDataRoot, salt, expectedMinipoolAddress, opts)
 	if err != nil {
 		return common.Address{}, nil, fmt.Errorf("Error executing deposit: %w", err)
 	}
-	txReceipt, err := utils.WaitForTransaction(rp.Client, hash)
+	txReceipt, err := utils.WaitForTransaction(rp.Client, tx.Hash())
 	if err != nil {
 		return common.Address{}, nil, fmt.Errorf("Error waiting for deposit transaction: %w", err)
 	}


### PR DESCRIPTION
After the `Deposit` return type was updated in https://github.com/rocket-pool/rocketpool-go/pull/10, there was one usage in test code which wasn't updated. This picks up that change.

Noticed this while starting to poke around the repo in an actual IDE and seeing some warnings.