### PR TITLE
Migrate to common.BytesToHash from deprecated address.Hash()

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -447,7 +447,7 @@ func GetPricesSubmissions(rp *rocketpool.RocketPool, nodeAddress common.Address,
 	}
 	// Construct a filter query for relevant logs
 	addressFilter := []common.Address{*rocketNetworkPrices.Address}
-	topicFilter := [][]common.Hash{{rocketNetworkPrices.ABI.Events["PricesSubmitted"].ID}, {nodeAddress.Hash()}}
+	topicFilter := [][]common.Hash{{rocketNetworkPrices.ABI.Events["PricesSubmitted"].ID}, {common.BytesToHash(nodeAddress.Bytes())}}
 
 	// Get the event logs
 	logs, err := eth.GetLogs(rp, addressFilter, topicFilter, intervalSize, big.NewInt(int64(fromBlock)), nil, nil)
@@ -475,7 +475,7 @@ func GetBalancesSubmissions(rp *rocketpool.RocketPool, nodeAddress common.Addres
 	}
 	// Construct a filter query for relevant logs
 	addressFilter := []common.Address{*rocketNetworkBalances.Address}
-	topicFilter := [][]common.Hash{{rocketNetworkBalances.ABI.Events["BalancesSubmitted"].ID}, {nodeAddress.Hash()}}
+	topicFilter := [][]common.Hash{{rocketNetworkBalances.ABI.Events["BalancesSubmitted"].ID}, {common.BytesToHash(nodeAddress.Bytes())}}
 
 	// Get the event logs
 	logs, err := eth.GetLogs(rp, addressFilter, topicFilter, intervalSize, big.NewInt(int64(fromBlock)), nil, nil)


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/pull/28228#issuecomment-1788320934