### PR TITLE
Add setters to fields

### DIFF
--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -8,9 +8,6 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/rocket-pool/node-manager-core/beacon"
 )
 
 // ==================
@@ -28,28 +25,6 @@ type ICopyable interface {
 // ===================
 // === SimpleField ===
 // ===================
-
-func (f *SimpleField[ValueType]) Set(value ValueType) {
-	switch val := any(&f.value).(type) {
-	case **big.Int:
-		castedValue := any(value).(*big.Int)
-		*val = big.NewInt(0).Set(castedValue)
-	case *common.Address:
-		castedValue := any(value).(common.Address)
-		copy((*val).Bytes(), castedValue.Bytes())
-	case *common.Hash:
-		castedValue := any(value).(common.Hash)
-		copy((*val).Bytes(), castedValue.Bytes())
-	case *beacon.ValidatorPubkey:
-		castedValue := any(value).(beacon.ValidatorPubkey)
-		copy((*val)[:], castedValue[:])
-	case *[]byte:
-		castedValue := any(value).([]byte)
-		copy(*val, castedValue)
-	default:
-		f.value = value
-	}
-}
 
 func (f *SimpleField[ValueType]) Equals(other IEquatable) (bool, string, string) {
 	castedOther, ok := other.(*SimpleField[ValueType])
@@ -81,14 +56,6 @@ func (f *SimpleField[ValueType]) Copy(other ICopyable) {
 // === FormattedUint256Field ===
 // =============================
 
-func (f *FormattedUint256Field[ValueType]) Set(value ValueType) {
-	f.value = GetValueForUint256(value)
-}
-
-func (f *FormattedUint256Field[ValueType]) SetRawValue(value *big.Int) {
-	f.value = big.NewInt(0).Set(value)
-}
-
 func (f *FormattedUint256Field[ValueType]) Equals(other IEquatable) (bool, string, string) {
 	castedOther, ok := other.(*FormattedUint256Field[ValueType])
 	if !ok {
@@ -108,11 +75,6 @@ func (f *FormattedUint256Field[ValueType]) Copy(other ICopyable) {
 // ===========================
 // === FormattedUint8Field ===
 // ===========================
-
-// Gets the raw value after it's been queried
-func (f *FormattedUint8Field[ValueType]) Set(value ValueType) {
-	f.value = uint8(value)
-}
 
 func (f *FormattedUint8Field[ValueType]) Equals(other IEquatable) (bool, string, string) {
 	castedOther, ok := other.(*FormattedUint8Field[ValueType])

--- a/minipool/manager.go
+++ b/minipool/manager.go
@@ -48,10 +48,17 @@ type MinipoolManager struct {
 	// The effective capacity of the minipool queue (used in node demand calculation)
 	EffectiveQueueCapacity *core.SimpleField[*big.Int]
 
+	// The amount of ETH required to include when creating a minipool (entering initialize / prelaunch)
+	PrelaunchValue *core.SimpleField[*big.Int]
+
+	// The amount of ETH that will be sent from a minipool to the Beacon deposit contract when staking the minipool
+	StakeValue *core.SimpleField[*big.Int]
+
 	// === Internal fields ===
 	rp    *rocketpool.RocketPool
 	mpMgr *core.Contract
 	mq    *core.Contract
+	dpsm  *core.Contract
 }
 
 // The counts of minipools per status
@@ -83,6 +90,10 @@ func NewMinipoolManager(rp *rocketpool.RocketPool) (*MinipoolManager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting minipool queue contract: %w", err)
 	}
+	dpsm, err := rp.GetContract(rocketpool.ContractName_RocketDAOProtocolSettingsMinipool)
+	if err != nil {
+		return nil, fmt.Errorf("error getting minipool DAO protocol settings contract: %w", err)
+	}
 
 	return &MinipoolManager{
 		// MinipoolManager
@@ -97,9 +108,14 @@ func NewMinipoolManager(rp *rocketpool.RocketPool) (*MinipoolManager, error) {
 		TotalQueueCapacity:     core.NewSimpleField[*big.Int](mq, "getTotalCapacity"),
 		EffectiveQueueCapacity: core.NewSimpleField[*big.Int](mq, "getEffectiveCapacity"),
 
+		// DAOProtocolSettingsMinipool
+		PrelaunchValue: core.NewSimpleField[*big.Int](dpsm, "getPreLaunchValue"),
+		StakeValue:     core.NewSimpleField[*big.Int](dpsm, "getVariableDepositAmount"),
+
 		rp:    rp,
 		mpMgr: mpMgr,
 		mq:    mq,
+		dpsm:  dpsm,
 	}, nil
 }
 

--- a/minipool/manager.go
+++ b/minipool/manager.go
@@ -48,6 +48,9 @@ type MinipoolManager struct {
 	// The effective capacity of the minipool queue (used in node demand calculation)
 	EffectiveQueueCapacity *core.SimpleField[*big.Int]
 
+	// The complete amount of ETH required for a validator to be activated on the Beacon Chain.
+	LaunchBalance *core.SimpleField[*big.Int]
+
 	// The amount of ETH required to include when creating a minipool (entering initialize / prelaunch)
 	PrelaunchValue *core.SimpleField[*big.Int]
 
@@ -109,6 +112,7 @@ func NewMinipoolManager(rp *rocketpool.RocketPool) (*MinipoolManager, error) {
 		EffectiveQueueCapacity: core.NewSimpleField[*big.Int](mq, "getEffectiveCapacity"),
 
 		// DAOProtocolSettingsMinipool
+		LaunchBalance:  core.NewSimpleField[*big.Int](dpsm, "getLaunchBalance"),
 		PrelaunchValue: core.NewSimpleField[*big.Int](dpsm, "getPreLaunchValue"),
 		StakeValue:     core.NewSimpleField[*big.Int](dpsm, "getVariableDepositAmount"),
 

--- a/node/node.go
+++ b/node/node.go
@@ -80,6 +80,9 @@ type Node struct {
 	// The time the node last staked RPL
 	RplStakedTime *core.FormattedUint256Field[time.Time]
 
+	// The amount of ETH the node has provided as a bond to create its minipools
+	EthProvided *core.SimpleField[*big.Int]
+
 	// The amount of ETH the node has borrowed from the deposit pool to create its minipools
 	EthMatched *core.SimpleField[*big.Int]
 
@@ -209,6 +212,7 @@ func NewNode(rp *rocketpool.RocketPool, address common.Address) (*Node, error) {
 		MinimumRplStake:     core.NewSimpleField[*big.Int](nodeStaking, "getNodeMinimumRPLStake", address),
 		MaximumRplStake:     core.NewSimpleField[*big.Int](nodeStaking, "getNodeMaximumRPLStake", address),
 		RplStakedTime:       core.NewFormattedUint256Field[time.Time](nodeStaking, "getNodeRPLStakedTime", address),
+		EthProvided:         core.NewSimpleField[*big.Int](nodeStaking, "getNodeETHProvided", address),
 		EthMatched:          core.NewSimpleField[*big.Int](nodeStaking, "getNodeETHMatched", address),
 		EthMatchedLimit:     core.NewSimpleField[*big.Int](nodeStaking, "getNodeETHMatchedLimit", address),
 		RplLocked:           core.NewSimpleField[*big.Int](nodeStaking, "getNodeRPLLocked", address),

--- a/node/node.go
+++ b/node/node.go
@@ -341,6 +341,11 @@ func (c *Node) StakeRpl(rplAmount *big.Int, opts *bind.TransactOpts) (*eth.Trans
 	return c.txMgr.CreateTransactionInfo(c.nodeStaking.Contract, "stakeRPL", opts, rplAmount)
 }
 
+// Get info for staking RPL on behalf of this node - should be called by something other than the node itself
+func (c *Node) StakeRplFor(rplAmount *big.Int, opts *bind.TransactOpts) (*eth.TransactionInfo, error) {
+	return c.txMgr.CreateTransactionInfo(c.nodeStaking.Contract, "stakeRPLFor", opts, c.Address, rplAmount)
+}
+
 // Get info for adding or removing an address from the stake-RPL-on-behalf allowlist
 func (c *Node) SetStakeRplForAllowed(caller common.Address, allowed bool, opts *bind.TransactOpts) (*eth.TransactionInfo, error) {
 	return c.txMgr.CreateTransactionInfo(c.nodeStaking.Contract, "setStakeRPLForAllowed", opts, caller, allowed)


### PR DESCRIPTION
This PR primarily moves the setters for contract fields out of unit testing code and into the public API. Right now the only way to set things is via contract queries, so this just allows users to directly set them as well.

As a side-effect this also adds some bindings that were missing for contract methods like `getPreLaunchValue` / `getVariableDepositAmount`.

NOTE: this PR builds on https://github.com/rocket-pool/rocketpool-go/pull/28 so if you merge this then that gets merged for free as part of it. 