### PR TITLE
Added Houston 1.3.1 Hotfix to Version Checker 

### DIFF
--- a/network/voting.go
+++ b/network/voting.go
@@ -18,6 +18,15 @@ const (
 	nodeVotingDetailsBatchSize uint64 = 250
 )
 
+// Get the version of the Rocket Network Voting Contract
+func GetRocketNetworkVotingVersion(rp *rocketpool.RocketPool, opts *bind.CallOpts) (uint8, error) {
+	rocketNetworkVoting, err := getRocketNetworkVoting(rp, opts)
+	if err != nil {
+		return 0, err
+	}
+	return rocketpool.GetContractVersion(rp, *rocketNetworkVoting.Address, opts)
+}
+
 // Gets the voting power and delegation info for every node at the specified block using multicall
 func GetNodeInfoSnapshotFast(rp *rocketpool.RocketPool, blockNumber uint32, multicallAddress common.Address, opts *bind.CallOpts) ([]types.NodeVotingInfo, error) {
 	rocketNetworkVoting, err := getRocketNetworkVoting(rp, opts)

--- a/utils/version-checker.go
+++ b/utils/version-checker.go
@@ -5,11 +5,21 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/hashicorp/go-version"
+	"github.com/rocket-pool/rocketpool-go/network"
 	"github.com/rocket-pool/rocketpool-go/node"
 	"github.com/rocket-pool/rocketpool-go/rocketpool"
 )
 
 func GetCurrentVersion(rp *rocketpool.RocketPool, opts *bind.CallOpts) (*version.Version, error) {
+
+	// Check for v1.3.1 (Houston Hotfix)
+	networkVotingVersion, err := network.GetRocketNetworkVotingVersion(rp, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error checking network voting version: %w", err)
+	}
+	if networkVotingVersion > 1 {
+		return version.NewSemver("1.3.1")
+	}
 
 	nodeMgrVersion, err := node.GetNodeManagerVersion(rp, opts)
 	if err != nil {


### PR DESCRIPTION
1.3.1 bumps the version of `RocketNetworkVoting.sol` from [1 to 2](https://github.com/rocket-pool/rocketpool/commit/c366a5566b525971c407fcb0c1eb22d74c7dc2c7#diff-df8852e7716247d182e056ac0c225e006fc0634d7dafe0c3e3e57e3403a6af26L27) so we can use this to check if the hotfix has been deployed. 