### PR TITLE
Rename provided to bonded, matched to borrowed. 

### DIFF
--- a/node/staking.go
+++ b/node/staking.go
@@ -164,81 +164,81 @@ func GetNodeETHCollateralisationRatio(rp *rocketpool.RocketPool, nodeAddress com
 }
 
 // Get the amount of ETH the node has borrowed from the deposit pool
-func GetNodeEthMatched(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
+func GetNodeETHBorrowed(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
 	rocketNodeStaking, err := getRocketNodeStaking(rp, opts)
 	if err != nil {
 		return nil, err
 	}
-	nodeEthMatched := new(*big.Int)
-	if err := rocketNodeStaking.Call(opts, nodeEthMatched, "getNodeETHMatched", nodeAddress); err != nil {
+	nodeETHBorrowed := new(*big.Int)
+	if err := rocketNodeStaking.Call(opts, nodeETHBorrowed, "getNodeETHBorrowed", nodeAddress); err != nil {
 		return nil, fmt.Errorf("error getting node ETH matched: %w", err)
 	}
-	return *nodeEthMatched, nil
+	return *nodeETHBorrowed, nil
 }
 
 // Get the amount of ETH the node has borrowed from the deposit pool for its megapool
-func GetNodeMegapoolEthMatched(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
+func GetNodeMegapoolETHBorrowed(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
 	rocketNodeStaking, err := getRocketNodeStaking(rp, opts)
 	if err != nil {
 		return nil, err
 	}
-	nodeEthMatched := new(*big.Int)
-	if err := rocketNodeStaking.Call(opts, nodeEthMatched, "getNodeMegapoolETHMatched", nodeAddress); err != nil {
+	nodeMegapoolETHBorrowed := new(*big.Int)
+	if err := rocketNodeStaking.Call(opts, nodeMegapoolETHBorrowed, "getNodeMegapoolETHBorrowed", nodeAddress); err != nil {
 		return nil, fmt.Errorf("error getting node ETH matched: %w", err)
 	}
-	return *nodeEthMatched, nil
+	return *nodeMegapoolETHBorrowed, nil
 }
 
 // Get the amount of ETH the node has borrowed from the deposit pool for its minipools
-func GetNodeMinipoolEthMatched(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
+func GetNodeMinipoolETHBorrowed(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
 	rocketNodeStaking, err := getRocketNodeStaking(rp, opts)
 	if err != nil {
 		return nil, err
 	}
-	nodeEthMatched := new(*big.Int)
-	if err := rocketNodeStaking.Call(opts, nodeEthMatched, "getNodeMinipoolETHMatched", nodeAddress); err != nil {
+	nodeMinipoolETHBorrowed := new(*big.Int)
+	if err := rocketNodeStaking.Call(opts, nodeMinipoolETHBorrowed, "getNodeMinipoolETHBorrowed", nodeAddress); err != nil {
 		return nil, fmt.Errorf("error getting node ETH matched: %w", err)
 	}
-	return *nodeEthMatched, nil
+	return *nodeMinipoolETHBorrowed, nil
 }
 
-// Get the amount of ETH the node has provided
-func GetNodeEthProvided(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
+// Get the amount of ETH the node has bonded
+func GetNodeEthBonded(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
 	rocketNodeStaking, err := getRocketNodeStaking(rp, opts)
 	if err != nil {
 		return nil, err
 	}
-	nodeEthProvided := new(*big.Int)
-	if err := rocketNodeStaking.Call(opts, nodeEthProvided, "getNodeETHProvided", nodeAddress); err != nil {
+	nodeETHBonded := new(*big.Int)
+	if err := rocketNodeStaking.Call(opts, nodeETHBonded, "getNodeETHBonded", nodeAddress); err != nil {
 		return nil, fmt.Errorf("error getting node ETH matched: %w", err)
 	}
-	return *nodeEthProvided, nil
+	return *nodeETHBonded, nil
 }
 
-// Get the amount of ETH the node has provided for its megapool
-func GetNodeMegapoolEthProvided(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
+// Get the amount of ETH the node has bonded for its megapool
+func GetNodeMegapoolETHBonded(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
 	rocketNodeStaking, err := getRocketNodeStaking(rp, opts)
 	if err != nil {
 		return nil, err
 	}
-	nodeEthProvided := new(*big.Int)
-	if err := rocketNodeStaking.Call(opts, nodeEthProvided, "getNodeMegapoolETHProvided", nodeAddress); err != nil {
+	nodeMegapoolETHBonded := new(*big.Int)
+	if err := rocketNodeStaking.Call(opts, nodeMegapoolETHBonded, "getNodeMegapoolETHBonded", nodeAddress); err != nil {
 		return nil, fmt.Errorf("error getting node ETH matched: %w", err)
 	}
-	return *nodeEthProvided, nil
+	return *nodeMegapoolETHBonded, nil
 }
 
-// Get the amount of ETH the node has provided for its minipools
-func GetNodeMinipoolEthProvided(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
+// Get the amount of ETH the node has bonded for its minipools
+func GetNodeMinipoolETHBonded(rp *rocketpool.RocketPool, nodeAddress common.Address, opts *bind.CallOpts) (*big.Int, error) {
 	rocketNodeStaking, err := getRocketNodeStaking(rp, opts)
 	if err != nil {
 		return nil, err
 	}
-	nodeEthProvided := new(*big.Int)
-	if err := rocketNodeStaking.Call(opts, nodeEthProvided, "getNodeMinipoolETHProvided", nodeAddress); err != nil {
+	nodeMinipoolETHBonded := new(*big.Int)
+	if err := rocketNodeStaking.Call(opts, nodeMinipoolETHBonded, "getNodeMinipoolETHBonded", nodeAddress); err != nil {
 		return nil, fmt.Errorf("error getting node ETH matched: %w", err)
 	}
-	return *nodeEthProvided, nil
+	return *nodeMinipoolETHBonded, nil
 }
 
 // Estimate the gas of Stake

--- a/utils/state/node.go
+++ b/utils/state/node.go
@@ -32,8 +32,8 @@ type NativeNodeDetails struct {
 	EffectiveRPLStake                *big.Int       `json:"effective_rpl_stake"`
 	MinimumRPLStake                  *big.Int       `json:"minimum_rpl_stake"`
 	MaximumRPLStake                  *big.Int       `json:"maximum_rpl_stake"`
-	EthMatched                       *big.Int       `json:"eth_matched"`
-	EthMatchedLimit                  *big.Int       `json:"eth_matched_limit"`
+	EthBorrowed                      *big.Int       `json:"eth_borrowed"`
+	EthBorrowedLimit                 *big.Int       `json:"eth_borrowed_limit"`
 	MinipoolCount                    *big.Int       `json:"minipool_count"`
 	BalanceETH                       *big.Int       `json:"balance_eth"`
 	BalanceRETH                      *big.Int       `json:"balance_reth"`
@@ -334,12 +334,15 @@ func addNodeDetailsCalls(contracts *NetworkContracts, mc *multicall.MultiCaller,
 	mc.AddCall(contracts.RocketNodeManager, &details.FeeDistributorInitialised, "getFeeDistributorInitialised", address)
 	mc.AddCall(contracts.RocketNodeDistributorFactory, &details.FeeDistributorAddress, "getProxyAddress", address)
 	mc.AddCall(contracts.RocketNodeManager, &details.RewardNetwork, "getRewardNetwork", address)
-	mc.AddCall(contracts.RocketNodeStaking, &details.RplStake, "getNodeRPLStake", address)
-	mc.AddCall(contracts.RocketNodeStaking, &details.EffectiveRPLStake, "getNodeEffectiveRPLStake", address)
-	mc.AddCall(contracts.RocketNodeStaking, &details.MinimumRPLStake, "getNodeMinimumRPLStake", address)
-	mc.AddCall(contracts.RocketNodeStaking, &details.MaximumRPLStake, "getNodeMaximumRPLStake", address)
-	mc.AddCall(contracts.RocketNodeStaking, &details.EthMatched, "getNodeETHMatched", address)
-	mc.AddCall(contracts.RocketNodeStaking, &details.EthMatchedLimit, "getNodeETHMatchedLimit", address)
+	if !contracts.isSaturnDeployed() {
+		mc.AddCall(contracts.RocketNodeStaking, &details.RplStake, "getNodeRPLStake", address)
+		mc.AddCall(contracts.RocketNodeStaking, &details.EffectiveRPLStake, "getNodeEffectiveRPLStake", address)
+		mc.AddCall(contracts.RocketNodeStaking, &details.MinimumRPLStake, "getNodeMinimumRPLStake", address)
+		mc.AddCall(contracts.RocketNodeStaking, &details.MaximumRPLStake, "getNodeMaximumRPLStake", address)
+		// Matched is renamed to borrowed in Saturn v1.4
+		mc.AddCall(contracts.RocketNodeStaking, &details.EthBorrowed, "getNodeETHMatched", address)
+		mc.AddCall(contracts.RocketNodeStaking, &details.EthBorrowedLimit, "getNodeETHMatchedLimit", address)
+	}
 	mc.AddCall(contracts.RocketMinipoolManager, &details.MinipoolCount, "getNodeMinipoolCount", address)
 	mc.AddCall(contracts.RocketTokenRETH, &details.BalanceRETH, "balanceOf", address)
 	mc.AddCall(contracts.RocketTokenRPL, &details.BalanceRPL, "balanceOf", address)
@@ -355,6 +358,7 @@ func addNodeDetailsCalls(contracts *NetworkContracts, mc *multicall.MultiCaller,
 
 	// Saturn
 	if contracts.isSaturnDeployed() {
+		mc.AddCall(contracts.RocketNodeStaking, &details.EthBorrowed, "getNodeETHBorrowed", address)
 		mc.AddCall(contracts.RocketMegapoolFactory, &details.MegapoolAddress, "getExpectedAddress", address)
 		mc.AddCall(contracts.RocketMegapoolFactory, &details.MegapoolDeployed, "getMegapoolDeployed", address)
 	}


### PR DESCRIPTION
This PR updates the `rp-go` bindings to support naming scheme changes made to the `RocketNodeStaking` interface. 

 Updated RocketNodeStaking naming: https://github.com/rocket-pool/rocketpool/commit/574e69f2fb3765be94d27cc652b12708f7499ba9

Additionally, a number of calls that don't exist on the latest RocketNodeStaking have been wrapped in an `isSaturnDeployed` check. 

Latest `RocketNodeStaking` interface: https://github.com/rocket-pool/rocketpool/commit/80aba5ecd196ce736488a4c90a36e4dfe8b62cf3